### PR TITLE
Alpine-ize graylog

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'graylog' -a "$(id -u)" = '0' ]; then
     fi
   done
   # Start Graylog server
-  set -- gosu graylog "$JAVA_HOME/bin/java" $GRAYLOG_SERVER_JAVA_OPTS \
+  set -- su-exec graylog "$JAVA_HOME/bin/java" $GRAYLOG_SERVER_JAVA_OPTS \
       -jar \
       -Dlog4j.configurationFile=/usr/share/graylog/data/config/log4j2.xml \
       -Djava.library.path=/usr/share/graylog/lib/sigar/ \


### PR DESCRIPTION
> This shaves about 30% from the resulting image size and uses musl instead of glibc.

As per: https://github.com/Graylog2/graylog2-images/pull/200#issuecomment-322451008

Haven't tested this build, but the changes are fairly straightforward.

I removed `JAVA_HOME` as it's already defined in the FROM image (for both plain `java:8-jre` and the alpine version)