### PR TITLE
The new Graylog 2.3.x needs that elasticsearch have http.compression enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ docker run --name some-mongo -d mongo:3
 
 Start Elasticsearch
 ```
-$ docker run --name some-elasticsearch -d elasticsearch:2 elasticsearch -Des.cluster.name="graylog"
+$ docker run --name some-elasticsearch -d elasticsearch:2 elasticsearch -Des.cluster.name="graylog" -Dhttp.compression=true
 ```
 
 Run Graylog server and link with the other two


### PR DESCRIPTION
The new Graylog 2.3.x needs that elasticsearch have http.compression enable

**Graylog2**
```
ERROR: org.graylog2.periodical.IndexRotationThread - Couldn't point deflector to a new index
org.graylog2.indexer.ElasticsearchException: Unable to create index template graylog-internal
```

**Elasticsearch without http.compression**
```
[WARN ][http.netty               ] [Architect] Caught exception while handling client http traffic, closing connection [id: 0xca958d3c, /172.17.0.6:43634 => /172.17.0.5:9200]
TransportException[Support for compressed content is disabled. You can enable it with http.compression=true]
```