### PR TITLE
Auto-default rest_transport_uri to enable Swarm stack deploys

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,8 @@ fi
 rm -f /tmp/graylog.pid
 
 if [[ ! -v GRAYLOG_REST_TRANSPORT_URI ]]; then
-    export GRAYLOG_REST_TRANSPORT_URI=$(hostname -i)
+  export GRAYLOG_REST_TRANSPORT_URI="http://$(hostname -i):9000/api/"
+  echo "Using GRAYLOG_REST_TRANSPORT_URI=${GRAYLOG_REST_TRANSPORT_URI}"
 fi
 
 # Create data directories

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,10 @@ fi
 # Delete outdated PID file
 rm -f /tmp/graylog.pid
 
+if [[ ! -v GRAYLOG_REST_TRANSPORT_URI ]]; then
+    export GRAYLOG_REST_TRANSPORT_URI=$(hostname -i)
+fi
+
 # Create data directories
 if [ "$1" = 'graylog' -a "$(id -u)" = '0' ]; then
   for d in journal log plugin config contentpacks; do


### PR DESCRIPTION
During Swarm stack deploys the container gets an additional virtual eth device that throws off the fallback logic to find the node's transport address. As a result, the errors below are observed in the log and the the web UI's `/system/nodes` interface can't show details of its own node.

It turns out `hostname -i` reports the correct, routable IP address of the container in both regular docker-compose and swarm stack deploys.

## Example interfaces when Swarm deployed:

The first, non-loopback interface is "eth2", but it's not usable for self-API and inter-container connections:

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet 10.0.0.7/32 scope global lo
       valid_lft forever preferred_lft forever
    inet 10.255.0.87/32 scope global lo
       valid_lft forever preferred_lft forever
2: tunl0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN group default qlen 1
    link/ipip 0.0.0.0 brd 0.0.0.0
3: ip6tnl0@NONE: <NOARP> mtu 1452 qdisc noop state DOWN group default qlen 1
    link/tunnel6 :: brd ::
136: eth2@if137: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
    link/ether 02:42:0a:ff:00:58 brd ff:ff:ff:ff:ff:ff link-netnsid 2
    inet 10.255.0.88/16 scope global eth2
       valid_lft forever preferred_lft forever
138: eth1@if139: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether 02:42:ac:1a:00:06 brd ff:ff:ff:ff:ff:ff link-netnsid 1
    inet 172.26.0.6/16 scope global eth1
       valid_lft forever preferred_lft forever
140: eth0@if141: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
    link/ether 02:42:0a:00:00:08 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 10.0.0.8/24 scope global eth0
       valid_lft forever preferred_lft forever    
```

## From container logs

Before PR, when using `docker swarm deploy --container-file docker-compose.yml graylog`:

```
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 2017-11-13 16:51:55,737 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Unable to call http://10.255.0.22:9000/api/system/metrics/multiple on node <bbf9beaa-e8c8-494a-9818-eb8ad685362b>
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | java.net.SocketTimeoutException: connect timed out
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_141]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_141]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_141]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_141]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_141]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_141]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.platform.Platform.connectSocket(Platform.java:124) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:223) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:149) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.connection.StreamAllocation.findConnection(StreamAllocation.java:192) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.connection.StreamAllocation.findHealthyConnection(StreamAllocation.java:121) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.connection.StreamAllocation.newStream(StreamAllocation.java:100) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:42) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:93) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:120) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at org.graylog2.rest.RemoteInterfaceProvider.lambda$get$0(RemoteInterfaceProvider.java:59) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:185) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at okhttp3.RealCall.execute(RealCall.java:69) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at retrofit2.OkHttpCall.execute(OkHttpCall.java:180) ~[graylog.jar:?]
graylog_graylog.1.ukm33fv68cec@linuxkit-025000000001    | 	at org.graylog2.shared.rest.resources.ProxiedResource.lambda$getForAllNodes$0(ProxiedResource.java:76) ~[graylog.jar:?]
```