### PR TITLE
optimize Dockerfile, add healthcheck and other small changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ RUN \
 
 
 COPY docker-entrypoint.sh /
+COPY health_check.sh /
 
 EXPOSE 9000
 VOLUME ${GRAYLOG_HOME}/data
@@ -127,7 +128,7 @@ HEALTHCHECK \
   --interval=10s \
   --timeout=2s \
   --retries=12 \
-  CMD curl --silent --fail http://localhost:9000/api/ || exit 1
+  CMD /health_check.sh
 
 # -------------------------------------------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,68 +1,145 @@
-FROM openjdk:8-jre
+# -------------------------------------------------------------------------------------------------
+#
+# layer for download and verifying
+FROM debian:stretch-slim as graylog-downloader
 
 ARG VCS_REF
 ARG GRAYLOG_VERSION
+
+WORKDIR /tmp
+
+# hadolint ignore=DL3008,DL3009,DL3014,DL3015
+RUN \
+  apt-get update  > /dev/null && \
+  apt-get install --assume-yes \
+    ca-certificates \
+    curl  > /dev/null
+
+RUN \
+  curl \
+    --silent \
+    --location \
+    --retry 3 \
+    --output "/tmp/graylog-${GRAYLOG_VERSION}.tgz" \
+    "https://packages.graylog2.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz"
+
+RUN \
+  curl \
+    --silent \
+    --location \
+    --retry 3 \
+    --output "/tmp/graylog-${GRAYLOG_VERSION}.tgz.sha256.txt" \
+    "https://packages.graylog2.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz.sha256.txt"
+
+RUN \
+  sha256sum --check "graylog-${GRAYLOG_VERSION}.tgz.sha256.txt"
+
+RUN \
+  mkdir /opt/graylog && \
+  tar --extract --gzip --file "/tmp/graylog-${GRAYLOG_VERSION}.tgz" --strip-components=1 --directory /opt/graylog
+
+RUN \
+  install \
+    --directory \
+    --mode=0750 \
+    /opt/graylog/data \
+    /opt/graylog/data/journal \
+    /opt/graylog/data/log \
+    /opt/graylog/data/config \
+    /opt/graylog/data/plugin
+
+# -------------------------------------------------------------------------------------------------
+#
+# final layer
+# use the smallest debain with headless openjdk and copying files from download layers
+FROM openjdk:8-jre-slim
+
+ARG VCS_REF
+ARG GRAYLOG_VERSION
+ARG BUILD_DATE
+ARG GRAYLOG_HOME=/usr/share/graylog
+ARG GRAYLOG_USER=graylog
+ARG GRAYLOG_UID=1100
+ARG GRAYLOG_GROUP=graylog
+ARG GRAYLOG_GID=1100
+
+# hadolint ignore=DL3023
+COPY --from=graylog-downloader /opt/graylog ${GRAYLOG_HOME}
+COPY config ${GRAYLOG_HOME}/data/config
+
+WORKDIR ${GRAYLOG_HOME}
+
+# hadolint ignore=DL3008,DL3014,SC2086
+RUN \
+  echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre" > /etc/profile.d/graylog.sh && \
+  echo "export BUILD_DATE=${BUILD_DATE}"           >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_VERSION=${GRAYLOG_VERSION}" >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_SERVER_JAVA_OPTS='-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow'" >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_HOME=${GRAYLOG_HOME}"       >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_USER=${GRAYLOG_USER}"       >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_GROUP=${GRAYLOG_GROUP}"     >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_UID=${GRAYLOG_UID}"         >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_GID=${GRAYLOG_GID}"         >> /etc/profile.d/graylog.sh && \
+  echo "export PATH=${GRAYLOG_HOME}/bin:${PATH}"   >> /etc/profile.d/graylog.sh && \
+  apt-get update  > /dev/null && \
+  apt-get install --no-install-recommends --assume-yes \
+    curl \
+    'gosu=1.10-*' \
+    libcap2-bin > /dev/null && \
+  addgroup \
+    --gid "${GRAYLOG_GID}" \
+    --quiet \
+    "${GRAYLOG_GROUP}" && \
+  adduser \
+    --disabled-password \
+    --disabled-login \
+    --gecos '' \
+    --home ${GRAYLOG_HOME} \
+    --uid "${GRAYLOG_UID}" \
+    --gid "${GRAYLOG_GID}" \
+    --quiet \
+    "${GRAYLOG_USER}" && \
+  chown --recursive "${GRAYLOG_USER}":"${GRAYLOG_GROUP}" ${GRAYLOG_HOME} && \
+  setcap 'cap_net_bind_service=+ep' "${JAVA_HOME}/bin/java" && \
+  apt-get remove --assume-yes --purge \
+    apt-utils > /dev/null && \
+  rm -f /etc/apt/sources.list.d/* && \
+  apt-get clean > /dev/null && \
+  apt autoremove --assume-yes > /dev/null && \
+  rm -rf \
+    /tmp/* \
+    /var/cache/debconf/* \
+    /var/lib/apt/lists/* \
+    /var/log/* \
+    /usr/share/X11 \
+    /usr/share/doc/* 2> /dev/null
+
+
+COPY docker-entrypoint.sh /
+
+EXPOSE 9000
+VOLUME ${GRAYLOG_HOME}/data
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["graylog"]
+
+# add healthcheck
+HEALTHCHECK \
+  --interval=10s \
+  --timeout=2s \
+  --retries=12 \
+  CMD curl --silent --fail http://localhost:9000/api/ || exit 1
+
+# -------------------------------------------------------------------------------------------------
 
 LABEL maintainer="Graylog, Inc. <hello@graylog.com>" \
       org.label-schema.name="Graylog Docker Image" \
       org.label-schema.description="Official Graylog Docker image" \
       org.label-schema.url="https://www.graylog.org/" \
-      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.vcs-url="https://github.com/Graylog2/graylog-docker" \
       org.label-schema.vendor="Graylog, Inc." \
-      org.label-schema.version=$GRAYLOG_VERSION \
+      org.label-schema.version=${GRAYLOG_VERSION} \
       org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=${BUILD_DATE} \
       com.microscaling.docker.dockerfile="/Dockerfile" \
       com.microscaling.license="Apache 2.0"
-
-ENV GOSU_VERSION 1.10
-RUN set -ex \
-  && wget -nv -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-  && wget -nv -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-  && GNUPGHOME="$(mktemp -d)" \
-  && export GNUPGHOME \
-  && gpg --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-  && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-  && chmod +x /usr/local/bin/gosu \
-  && gosu nobody true
-
-WORKDIR /tmp
-RUN set -ex \
-  && mkdir /usr/share/graylog \
-  && wget -nv -O "/tmp/graylog-${GRAYLOG_VERSION}.tgz" "https://packages.graylog2.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz" \
-  && wget -nv -O "/tmp/graylog-${GRAYLOG_VERSION}.tgz.sha256.txt" "https://packages.graylog2.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz.sha256.txt" \
-  && sha256sum -c "/tmp/graylog-${GRAYLOG_VERSION}.tgz.sha256.txt" \
-  && tar -xzf "/tmp/graylog-${GRAYLOG_VERSION}.tgz" --strip-components=1 -C /usr/share/graylog \
-  && rm -f "/tmp/graylog-${GRAYLOG_VERSION}.tgz" \
-  && addgroup --gid 1100 graylog \
-  && adduser --disabled-password --disabled-login --gecos '' --uid 1100 --gid 1100 graylog \
-  && chown -R graylog:graylog /usr/share/graylog
-
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
-ENV GRAYLOG_SERVER_JAVA_OPTS "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow"
-ENV PATH /usr/share/graylog/bin:$PATH
-
-WORKDIR /usr/share/graylog
-RUN set -ex \
-  && for path in \
-    ./data/journal \
-    ./data/log \
-    ./data/config \
-  ; do \
-    mkdir -p "$path"; \
-  done
-COPY config ./data/config
-COPY docker-entrypoint.sh /
-
-EXPOSE 9000
-VOLUME /usr/share/graylog/data
-ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["graylog"]
-
-# hadolint ignore=DL3008
-RUN set -ex \
-  && apt-get update && apt-get -y --no-install-recommends install libcap2-bin \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && setcap 'cap_net_bind_service=+ep' "${JAVA_HOME}/bin/java"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,33 +2,34 @@
 
 set -e
 
+source /etc/profile
+
 if [ "${1:0:1}" = '-' ]; then
   set -- graylog "$@"
 fi
 
 # Delete outdated PID file
-rm -f /tmp/graylog.pid
+[[ -e /tmp/graylog.pid ]] && rm --force /tmp/graylog.pid
 
 # Create data directories
-if [ "$1" = 'graylog' ] && [ "$(id -u)" = '0' ]; then
+if [[ "$1" = 'graylog' ]] && [[ "$(id -u)" = '0' ]]; then
   for d in journal log plugin config contentpacks; do
-    dir=/usr/share/graylog/data/$d
-    if [[ ! -d "$dir" ]]; then
-      mkdir -p "$dir"
-    fi
-    if [[ "$(stat --format='%U:%G' $dir)" != 'graylog:graylog' ]] && [[ -w "$dir" ]]; then
-      chown -R graylog:graylog "$dir"
-    fi
+    dir=${GRAYLOG_HOME}/data/$d
+    [[ -d "${dir}" ]] || mkdir -p "${dir}"
   done
+
+  chown --recursive "${GRAYLOG_USER}":"${GRAYLOG_GROUP}" "${GRAYLOG_HOME}/data"
+
   # Start Graylog server
   # shellcheck disable=SC2086
-  set -- gosu graylog "$JAVA_HOME/bin/java" $GRAYLOG_SERVER_JAVA_OPTS \
+  set -- gosu ${GRAYLOG_USER} "${JAVA_HOME}/bin/java" ${GRAYLOG_SERVER_JAVA_OPTS} \
       -jar \
-      -Dlog4j.configurationFile=/usr/share/graylog/data/config/log4j2.xml \
-      -Djava.library.path=/usr/share/graylog/lib/sigar/ \
-      -Dgraylog2.installation_source=docker /usr/share/graylog/graylog.jar \
+      -Dlog4j.configurationFile=${GRAYLOG_HOME}/data/config/log4j2.xml \
+      -Djava.library.path=${GRAYLOG_HOME}/lib/sigar/ \
+      -Dgraylog2.installation_source=docker \
+      ${GRAYLOG_HOME}/graylog.jar \
       server \
-      -f /usr/share/graylog/data/config/graylog.conf ${GRAYLOG_SERVER_OPTS}
+      -f ${GRAYLOG_HOME}/data/config/graylog.conf ${GRAYLOG_SERVER_OPTS}
 fi
 
 # Allow the user to run arbitrarily commands like bash

--- a/health_check.sh
+++ b/health_check.sh
@@ -5,10 +5,17 @@ source /etc/profile
 set -eo pipefail
 
 host="$(hostname -i || echo '127.0.0.1')"
+
 port=9000
+tls=false
+proto=http
 
 # rest_listen_uri = http://0.0.0.0:9000/api/
 rest_listen_uri=$(grep "rest_listen_uri" ${GRAYLOG_HOME}/data/config/graylog.conf)
+#rest_enable_tls = true
+tls=$(grep "^rest_enable_tls" ${GRAYLOG_HOME}/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+
+[[ ${tls} = "true" ]] && proto=https
 
 if [[ ! -z "${GRAYLOG_WEB_ENDPOINT_URI}" ]]
 then
@@ -18,7 +25,7 @@ then
   port=$(echo -e "${rest_listen_uri}" | awk -F '=' '{print $2}' | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')
 fi
 
-if curl --silent --fail http://${host}:${port}/api
+if curl --silent --fail ${proto}://${host}:${port}/api
 then
   exit 0
 fi

--- a/health_check.sh
+++ b/health_check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source /etc/profile
+
+set -eo pipefail
+
+host="$(hostname -i || echo '127.0.0.1')"
+port=9000
+
+# rest_listen_uri = http://0.0.0.0:9000/api/
+rest_listen_uri=$(grep "rest_listen_uri" ${GRAYLOG_HOME}/data/config/graylog.conf)
+
+if [[ ! -z "${GRAYLOG_WEB_ENDPOINT_URI}" ]]
+then
+  port=$(echo "${GRAYLOG_WEB_ENDPOINT_URI}" | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')
+elif [[ ! -z "${rest_listen_uri}" ]]
+then
+  port=$(echo -e "${rest_listen_uri}" | awk -F '=' '{print $2}' | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')
+fi
+
+if curl --silent --fail http://${host}:${port}/api
+then
+  exit 0
+fi
+
+exit 1

--- a/health_check.sh
+++ b/health_check.sh
@@ -2,8 +2,6 @@
 
 source /etc/profile
 
-set -eo pipefail
-
 host="$(hostname -i || echo '127.0.0.1')"
 
 port=9000
@@ -15,7 +13,7 @@ rest_listen_uri=$(grep "rest_listen_uri" ${GRAYLOG_HOME}/data/config/graylog.con
 #rest_enable_tls = true
 tls=$(grep "^rest_enable_tls" ${GRAYLOG_HOME}/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
 
-[[ ${tls} = "true" ]] && proto=https
+[[ ! -z "${tls}" ]] && [[ ${tls} = "true" ]] && proto=https
 
 if [[ ! -z "${GRAYLOG_WEB_ENDPOINT_URI}" ]]
 then

--- a/hooks/build
+++ b/hooks/build
@@ -4,8 +4,7 @@
 # see: https://medium.com/microscaling-systems/labelling-automated-builds-on-docker-hub-f3d073fb8e1
 
 docker build \
-  --pull \
   --build-arg VCS_REF=$GIT_SHA1 \
   --build-arg GRAYLOG_VERSION=$(cat VERSION) \
   --build-arg BUILD_DATE=$(date +%Y-%m-%d) \
-  --tag bodsch-$IMAGE_NAME .
+  --tag $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -3,6 +3,9 @@
 # Custom build for Docker Hub
 # see: https://medium.com/microscaling-systems/labelling-automated-builds-on-docker-hub-f3d073fb8e1
 
-docker build --build-arg VCS_REF=$GIT_SHA1 \
-             --build-arg GRAYLOG_VERSION=`cat VERSION` \
-             --tag $IMAGE_NAME .
+docker build \
+  --pull \
+  --build-arg VCS_REF=$GIT_SHA1 \
+  --build-arg GRAYLOG_VERSION=$(cat VERSION) \
+  --build-arg BUILD_DATE=$(date +%Y-%m-%d) \
+  --tag bodsch-$IMAGE_NAME .

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -1,4 +1,8 @@
-#!/bin/bash -ex
+#!/bin/bash
+
+set -e
+set +x
+
 CREDENTIALS="admin:admin"
 URL="http://127.0.0.1:9000"
 

--- a/test/linter.sh
+++ b/test/linter.sh
@@ -7,4 +7,4 @@ if ! [ -x "$(command -v hadolint)" ]; then
 fi
 
 hadolint Dockerfile
-shellcheck docker-entrypoint.sh
+shellcheck docker-entrypoint.sh -x


### PR DESCRIPTION
When I looked at the https://github.com/Graylog2/graylog-docker/pull/31, I saw more possibilities for optimization.

- using a [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) to download and verify that I don't have it in the final container.
- use a headless jre to avoid further dependencies.
- configurable UID / GID for the graylog user (taken from @gertvdijk)
- a little more order and only one RUN layer left
- `HEALTHCHECK` added.
- wget replaced by curl
- use `/etc/profile.d/graylog.sh` to build and use environment variables
- use the configurable graylog user in the `docker-entrypoint.sh`

image size before my changes: 586MB
image size after my changes: 492MB
