### PR TITLE
updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Graylog Docker Image
 
-Latest stable Version of Graylog is *2.5.0* this Version is available with the tags `2.5` and `2.5.0-1`. 
+Latest stable version of Graylog is *2.5.0* this Version is available with the tags `2.5` or `2.5.0-1`. 
 
 [![Build Status](https://travis-ci.org/Graylog2/graylog-docker.svg?branch=2.5)](https://travis-ci.org/Graylog2/graylog-docker) [![Docker Stars](https://img.shields.io/docker/stars/graylog/graylog.svg)][hub] [![Docker Pulls](https://img.shields.io/docker/pulls/graylog/graylog.svg)][hub] [![Image Size](https://images.microbadger.com/badges/image/graylog/graylog:2.5.svg)][microbadger] [![Image Version](https://images.microbadger.com/badges/version/graylog/graylog:2.5.svg)][microbadger] [![Image License](https://images.microbadger.com/badges/license/graylog/graylog:2.5.svg)][microbadger]
 
@@ -13,7 +13,7 @@ In the current development branch we have builds for the upcoming versions avail
 [hub]: https://hub.docker.com/r/graylog/graylog/
 [microbadger]: https://microbadger.com/images/graylog/graylog
 
-Please use the stable `2.5` release for your production environments. Please check the [latest stable documentation](http://docs.graylog.org/en/stable/pages/installation/docker.html) for a complete installation and configuration instruction.
+Use the stable `2.5` release for your production environments. Please check the [latest stable documentation](http://docs.graylog.org/en/stable/pages/installation/docker.html) for complete installation and configuration instruction.
 
 
 ## What is Graylog?

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # Graylog Docker Image
 
-[![Build Status](https://travis-ci.org/Graylog2/graylog-docker.svg?branch=3.0)](https://travis-ci.org/Graylog2/graylog-docker)
-[![Docker Stars](https://img.shields.io/docker/stars/graylog/graylog.svg)][hub]
-[![Docker Pulls](https://img.shields.io/docker/pulls/graylog/graylog.svg)][hub]
-[![Image Size](https://images.microbadger.com/badges/image/graylog/graylog.svg)][microbadger]
-[![Image Version](https://images.microbadger.com/badges/version/graylog/graylog:3.0.svg)][microbadger]
-[![Image License](https://images.microbadger.com/badges/license/graylog/graylog:3.0.svg)][microbadger]
+Latest stable Version of Graylog is *2.5.0* this Version is available with the tags `2.5` and `2.5.0-1`. 
+
+[![Build Status](https://travis-ci.org/Graylog2/graylog-docker.svg?branch=2.5)](https://travis-ci.org/Graylog2/graylog-docker) [![Docker Stars](https://img.shields.io/docker/stars/graylog/graylog.svg)][hub] [![Docker Pulls](https://img.shields.io/docker/pulls/graylog/graylog.svg)][hub] [![Image Size](https://images.microbadger.com/badges/image/graylog/graylog:2.5.svg)][microbadger] [![Image Version](https://images.microbadger.com/badges/version/graylog/graylog:2.5.svg)][microbadger] [![Image License](https://images.microbadger.com/badges/license/graylog/graylog:2.5.svg)][microbadger]
+
+In the current development branch we have builds for the upcoming versions available. Those images can be identified in the [tag overview](https://hub.docker.com/r/graylog/graylog/tags/) of Docker Hub. Currently available are:
+
+
+- `3.0.0-alpha.5-1` [![Build Status](https://travis-ci.org/Graylog2/graylog-docker.svg?branch=3.0)](https://travis-ci.org/Graylog2/graylog-docker)
+
 
 [hub]: https://hub.docker.com/r/graylog/graylog/
 [microbadger]: https://microbadger.com/images/graylog/graylog
 
-# INSTABILITY WARNING
-Please be aware that Version 3.0 of Graylog is an alpha release and is still under development. Under no circumstances should this image be used in  production. Suitable for lab use only. This is a technical preview.
+Please use the stable `2.5` release for your production environments. Please check the [latest stable documentation](http://docs.graylog.org/en/stable/pages/installation/docker.html) for a complete installation and configuration instruction.
 
-Please use the stable 2.4 release for your production environments. 
 
 ## What is Graylog?
 
@@ -21,182 +22,15 @@ Graylog is a centralized logging solution that allows the user to aggregate and 
 
 ## Architecture
 
-Take a look at the minimal [Graylog architecture](http://docs.graylog.org/en/latest/pages/architecture.html) to get the big picture of a Graylog setup. In essence, Graylog needs to talk to MongoDB to store configuration data as well as Elasticsearch to store the actual log data.
+Take a look at the minimal [Graylog architecture](http://docs.graylog.org/en/stable/pages/architecture.html) to get the big picture of a Graylog setup. In essence, Graylog needs to talk to MongoDB to store configuration data as well as Elasticsearch to store the actual log data.
 
 ## How to use this image
 
-Please refer to the [Graylog Docker documentation](http://docs.graylog.org/en/3.0/pages/installation/docker.html) for a comprehensive overview and a detailed description of the Graylog Docker image.
+Please refer to the [Graylog Docker documentation](http://docs.graylog.org/en/stable/pages/installation/docker.html) for a comprehensive overview and a detailed description of the Graylog Docker image.
 
-### Quick start
-
-If you simply want to checkout Graylog without any further customization, you can run the following three commands to create the necessary environment:
-
-```
-$ docker run --name mongo -d mongo:3
-$ docker run --name elasticsearch \
-    -e "http.host=0.0.0.0" -e "xpack.security.enabled=false" \
-    -d docker.elastic.co/elasticsearch/elasticsearch:5.6.12
-$ docker run --link mongo --link elasticsearch \
-    -p 9000:9000 -p 12201:12201 -p 514:514 \
-    -e GRAYLOG_HTTP_EXTERNAL_URI="http://127.0.0.1:9000/" \
-    -d graylog/graylog:3.0
-```
-
-### Settings
-
-Graylog comes with a default configuration that works out of the box but you have to set a password for the admin user. Also the web interface needs to know how to connect from your browser to the Graylog API. Both can be done via environment variables.
-
-```
-  -e GRAYLOG_PASSWORD_SECRET=somepasswordpepper
-  -e GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
-  -e GRAYLOG_HTTP_EXTERNAL_URI="http://127.0.0.1:9000/"
-```
-In this case you can login to Graylog with the user and password `admin`.  Generate your own password with this command:
-
-```
-  # OSX
-  $ echo -n "Enter Password: " && head -1 </dev/stdin | tr -d '\n' | shasum -a 256 | cut -d" " -f1
-
-  # linux
-  $ echo -n "Enter Password: " && head -1 </dev/stdin | tr -d '\n' | sha256sum | cut -d" " -f1
-```
-
-This all can be put in a `docker-compose` file, like:
-
-```
-version: '2'
-services:
-  # MongoDB: https://hub.docker.com/_/mongo/
-  mongo:
-    image: mongo:3
-  # Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/docker.html
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.12
-    environment:
-      - http.host=0.0.0.0
-      # Disable X-Pack security: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/security-settings.html#general-security-settings
-      - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    mem_limit: 1g
-  # Graylog: https://hub.docker.com/r/graylog/graylog/
-  graylog:
-    image: graylog/graylog:3.0
-    environment:
-      # CHANGE ME!
-      - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
-      # Password: admin
-      - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
-      - GRAYLOG_HTTP_EXTERNAL_URI=http://127.0.0.1:9000/
-    links:
-      - mongo
-      - elasticsearch
-    ports:
-      # Graylog web interface and REST API
-      - 9000:9000
-      # Syslog TCP
-      - 514:514
-      # Syslog UDP
-      - 514:514/udp
-      # GELF TCP
-      - 12201:12201
-      # GELF UDP
-      - 12201:12201/udp
-```
-
-After starting the three containers with `docker-compose up` open your browser with the URL `http://127.0.0.1:9000` and login with `admin:admin`
-
-## Persist log data
-
-In order to make the log data and configuration of Graylog persistent, you can use external volumes to store all data. In case of a container restart simply re-use the existing data from the former instances.
-
-If you need to customize the configuration files for Graylog (such as the Log4j 2 configuration), you can download the vanilla files from GitHub and put them into a dedicated Docker volume.
-
-Create the configuration directory and copy the default files:
-
-```
-mkdir -p ./graylog/config
-cd ./graylog/config
-wget https://raw.githubusercontent.com/Graylog2/graylog-docker/3.0/config/graylog.conf
-wget https://raw.githubusercontent.com/Graylog2/graylog-docker/3.0/config/log4j2.xml
-```
-
-The `docker-compose.yml` file looks like this:
-
-```
-version: '2'
-services:
-  # MongoDB: https://hub.docker.com/_/mongo/
-  mongo:
-    image: mongo:3
-    volumes:
-      - mongo_data:/data/db
-  # Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/docker.html
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.12
-    volumes:
-      - es_data:/usr/share/elasticsearch/data
-    environment:
-      - http.host=0.0.0.0
-      - transport.host=localhost
-      - network.host=0.0.0.0
-      # Disable X-Pack security: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/security-settings.html#general-security-settings
-      - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    mem_limit: 1g
-  # Graylog: https://hub.docker.com/r/graylog/graylog/
-  graylog:
-    image: graylog/graylog:3.0
-    volumes:
-      - graylog_journal:/usr/share/graylog/data/journal
-      - ./graylog/config:/usr/share/graylog/data/config
-    environment:
-      # CHANGE ME!
-      - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
-      # Password: admin
-      - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
-      - GRAYLOG_HTTP_EXTERNAL_URI=http://127.0.0.1:9000/
-    links:
-      - mongo
-      - elasticsearch
-    ports:
-      # Graylog web interface and REST API
-      - 9000:9000
-      # Syslog TCP
-      - 514:514
-      # Syslog UDP
-      - 514:514/udp
-      # GELF TCP
-      - 12201:12201
-      # GELF UDP
-      - 12201:12201/udp
-
-# Volumes for persisting data, see https://docs.docker.com/engine/admin/volumes/volumes/
-volumes:
-  mongo_data:
-    driver: local
-  es_data:
-    driver: local
-  graylog_journal:
-    driver: local
-```
-
-Start all services with:
-
-```
-docker-compose up
-```
- 
 ## Configuration
 
-Every configuration option can be set via environment variables, take a look [here](https://github.com/Graylog2/graylog2-server/blob/master/misc/graylog.conf) for an overview. Simply prefix the parameter name with `GRAYLOG_` and put it all in upper case. Another option would be to store the configuration file outside of the container and edit it directly.
+Every configuration option can be set via environment variables, take a look [here](http://docs.graylog.org/en/stable/pages/configuration/server.conf.html) for an overview. Simply prefix the parameter name with `GRAYLOG_` and put it all in upper case. Another option would be to store the configuration file outside of the container and edit it directly.
 
 ## Documentation
 


### PR DESCRIPTION
created one readme without examples that would need to be updated and a clear statement about the current stable version. 

This Readme could be used for all versions without and it will be consistent on Docker UP, no matter what was the last push. As Docker Hub only takes the latest push readme and has no option to mark one as stable.

This needs then to be pushed to 2.5 and 2.4 branch too