### PR TITLE
Set GRAYLOG_IS_MASTER if hostname matches

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,6 +19,11 @@ if [ "${1:0:1}" = '-' ]; then
   set -- graylog "$@"
 fi
 
+# enable master flag if hostname matches
+if [ "$GRAYLOG_SERVER_MASTER_HOSTNAME" == "$HOSTNAME" ]; then
+  export GRAYLOG_IS_MASTER=true
+fi
+
 # Delete outdated PID file
 [[ -e /tmp/graylog.pid ]] && rm --force /tmp/graylog.pid
 


### PR DESCRIPTION
This will make graylog deployments in kubernetes alot easier...

Right now we have to define master and slave nodes in two stateful sets:
https://github.com/arvatoaws/graylog-helm-chart/blob/master/graylog/templates/graylog-master.yaml
https://github.com/arvatoaws/graylog-helm-chart/blob/master/graylog/templates/graylog-slave.yaml

We could combine them in one template with this fix.

This is my test script:
```
#!/bin/bash

export GRAYLOG_IS_MASTER=false

echo master hostname
echo $GRAYLOG_SERVER_MASTER_HOSTNAME
echo hostname
echo $HOSTNAME

# enable master flag if hostname matches
if [ "$GRAYLOG_SERVER_MASTER_HOSTNAME" == "$HOSTNAME" ]; then
  export GRAYLOG_IS_MASTER=true
fi

echo $GRAYLOG_IS_MASTER
```