### PR TITLE
repair healthcheck for custom path specified in GRAYLOG_REST_LISTEN_URI

### DIFF
--- a/health_check.sh
+++ b/health_check.sh
@@ -7,6 +7,7 @@ host="$(hostname -i || echo '127.0.0.1')"
 port=9000
 tls=false
 proto=http
+path=api
 
 # rest_listen_uri = http://0.0.0.0:9000/api/
 rest_listen_uri=$(grep "rest_listen_uri" ${GRAYLOG_HOME}/data/config/graylog.conf)
@@ -18,12 +19,14 @@ tls=$(grep "^rest_enable_tls" ${GRAYLOG_HOME}/data/config/graylog.conf | awk -F 
 if [[ ! -z "${GRAYLOG_REST_LISTEN_URI}" ]]
 then
   port=$(echo "${GRAYLOG_REST_LISTEN_URI}" | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')
+  path=$(echo "${GRAYLOG_REST_LISTEN_URI}" | sed -e 's,^.*:,:,g' -e 's,.*:[0-9]*\/\([^\/]*\),\1,g')
 elif [[ ! -z "${rest_listen_uri}" ]]
 then
   port=$(echo -e "${rest_listen_uri}" | awk -F '=' '{print $2}' | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')
+  path=$(echo -e "${rest_listen_uri}" | awk -F '=' '{print $2}' | sed -e 's,^.*:,:,g' -e 's,.*:[0-9]*\/\([^\/]*\),\1,g')
 fi
 
-if curl --silent --fail ${proto}://${host}:${port}/api
+if curl --silent --fail ${proto}://${host}:${port}/${path}
 then
   exit 0
 fi


### PR DESCRIPTION
We use a custom GRAYLOG_REST_LISTEN_URI with a different path than /api (e.g. http://0.0.0.0:9000/rest_api) in this case the healthcheck always marks the container as unhealthy because it cannot find the api under /api and graylog responds with a 404 status code for http://0.0.0.0:9000/api (at least since the upgrade to 2.5)

This pull request fixes the healthcheck to also consider a custom path specified in the GRAYLOG_REST_LISTEN_URI and rest_listen_uri variables.

Info @wt-io-it