### PR TITLE
Data directories chown warning instead of error

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,9 +46,11 @@ setup() {
   do
     dir=${GRAYLOG_HOME}/data/${d}
     [[ -d "${dir}" ]] || mkdir -p "${dir}"
+    
+    if [[ "$(stat --format='%U:%G' $dir)" != 'graylog:graylog' ]] && [[ -w "$dir" ]]; then
+      chown -R graylog:graylog "$dir" || echo "Warning can not change owner to graylog:graylog"
+    fi
   done
-
-  chown --recursive "${GRAYLOG_USER}":"${GRAYLOG_GROUP}" "${GRAYLOG_HOME}/data"
 }
 
 graylog() {


### PR DESCRIPTION
This PR fixes errors on startup, when mounting volumes to data directories like journal, log, plugin, config, contentpacks
Fixes https://github.com/Graylog2/graylog-docker/issues/62