### PR TITLE
updated health_check

### DIFF
--- a/health_check.sh
+++ b/health_check.sh
@@ -29,8 +29,8 @@ fi
 if [[ ! -z "${GRAYLOG_HTTP_PUBLISH_URI}" ]]
 then
 	# remove the protocol from the URI
-	proto="$(echo "${GRAYLOG_HTTP_PUBLISH_URI}" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
-	url=$(echo "${GRAYLOG_HTTP_PUBLISH_URI}" | sed -e s,"$proto",,g)
+	proton="$(echo "${GRAYLOG_HTTP_PUBLISH_URI}" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+	url=$(echo "${GRAYLOG_HTTP_PUBLISH_URI}" | sed -e s,"$proton",,g)
 	# we want to be sure to use https if enable
 	# currently this looks like the best solution to cut
 	# the protocoll away and set it based on 
@@ -52,12 +52,12 @@ fi
 # when HTTP_PUBLISH_URI is given that is used for the healtcheck
 # otherwise HTTP_BIND_ADDRESS
 
-if [[ ! -z "${http_publish_uri}" ]]
-then
-	check_url="${proto}"://"${http_publish_uri}"
-elif [[ ! -z "${http_bind_address}" ]]
+if [[ ! -z "${http_bind_address}" ]]
 then
 	check_url="${proto}"://"${http_bind_address}"
+elif [[ ! -z "${http_publish_uri}" ]]
+then
+	check_url="${proto}"://"${http_publish_uri}"
 else
 	echo "not possible to get Graylog listen URI - abort"
 	exit 1

--- a/health_check.sh
+++ b/health_check.sh
@@ -2,30 +2,70 @@
 
 source /etc/profile
 
-host="$(hostname -i || echo '127.0.0.1')"
 
-port=9000
-tls=false
+# http://docs.graylog.org/en/3.0/pages/configuration/server.conf.html#web-rest-api
+#
+# if `http_publish_uri` is given, use that for healthcheck,
+# if not take `http_bind_address` what defaults to 127.0.0.1
+# if nothing is set.
+#
+
+# defaults
 proto=http
+http_bind_address=127.0.0.1:9000
 
-# http_bind_address = http://0.0.0.0:9000/api/
-http_bind_address=$(grep "^http_bind_address" ${GRAYLOG_HOME}/data/config/graylog.conf)
-# http_enable_tls = true
-tls=$(grep "^http_enable_tls" ${GRAYLOG_HOME}/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+# check if configuration file is given and grep for variable
+if [[ -f "${GRAYLOG_HOME}"/data/config/graylog.conf ]]
+	then
+	# try to grep the variable from a mounted configuration
+	http_publish_uri=$(grep "^http_publish_uri" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+	http_bind_address=$(grep "^http_bind_address" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+	http_enable_tls=$(grep "^http_enable_tls" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+fi
 
-[[ ! -z "${tls}" ]] && [[ ${tls} = "true" ]] && proto=https
-
+# try to get the data from environment variables
+# they will always override all other settings
+# shellcheck disable=SC2001
+if [[ ! -z "${GRAYLOG_HTTP_PUBLISH_URI}" ]]
+	then
+	# remove the protocol from the URI
+	proto="$(echo "${GRAYLOG_HTTP_PUBLISH_URI}" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+	url=$(echo "${GRAYLOG_HTTP_PUBLISH_URI}" | sed -e s,"$proto",,g)
+	# we want to be sure to use https if enable
+	# currently this looks like the best solution to cut
+	# the protocoll away and set it based on 
+	# the fact if TLS is enabled or not
+	http_publish_uri="${url}"
+fi
 if [[ ! -z "${GRAYLOG_HTTP_BIND_ADDRESS}" ]]
-then
-  port=$(echo "${GRAYLOG_HTTP_BIND_ADDRESS}" | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')
+	then
+	http_bind_address="${GRAYLOG_HTTP_BIND_ADDRESS}"
+fi
+if [[ ! -z "${GRAYLOG_HTTP_ENABLE_TLS}" ]]
+	then
+	http_enable_tls="${GRAYLOG_HTTP_ENABLE_TLS}"
+fi
+
+# if configured set https
+[[ ! -z "${http_enable_tls}" ]] && [[ ${http_enable_tls} = "true" ]] && proto=https
+
+# when HTTP_PUBLISH_URI is given that is used for the healtcheck
+# otherwise HTTP_BIND_ADDRESS
+
+if [[ ! -z "${http_publish_uri}" ]]
+	then
+	check_url="${proto}"://"${http_publish_uri}"
 elif [[ ! -z "${http_bind_address}" ]]
-then
-  port=$(echo -e "${http_bind_address}" | awk -F '=' '{print $2}' | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')
+	then
+	check_url="${proto}"://"${http_bind_address}"
+else
+	echo "not possible to get Graylog listen URI - abort"
+	exit 1
 fi
 
-if curl --silent --fail ${proto}://${host}:${port}/api
-then
-  exit 0
-fi
 
+if curl --silent --fail "${check_url}"/api
+	then
+  	exit 0
+fi
 exit 1

--- a/health_check.sh
+++ b/health_check.sh
@@ -16,7 +16,7 @@ http_bind_address=127.0.0.1:9000
 
 # check if configuration file is given and grep for variable
 if [[ -f "${GRAYLOG_HOME}"/data/config/graylog.conf ]]
-	then
+then
 	# try to grep the variable from a mounted configuration
 	http_publish_uri=$(grep "^http_publish_uri" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
 	http_bind_address=$(grep "^http_bind_address" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
@@ -27,7 +27,7 @@ fi
 # they will always override all other settings
 # shellcheck disable=SC2001
 if [[ ! -z "${GRAYLOG_HTTP_PUBLISH_URI}" ]]
-	then
+then
 	# remove the protocol from the URI
 	proto="$(echo "${GRAYLOG_HTTP_PUBLISH_URI}" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
 	url=$(echo "${GRAYLOG_HTTP_PUBLISH_URI}" | sed -e s,"$proto",,g)
@@ -38,11 +38,11 @@ if [[ ! -z "${GRAYLOG_HTTP_PUBLISH_URI}" ]]
 	http_publish_uri="${url}"
 fi
 if [[ ! -z "${GRAYLOG_HTTP_BIND_ADDRESS}" ]]
-	then
+then
 	http_bind_address="${GRAYLOG_HTTP_BIND_ADDRESS}"
 fi
 if [[ ! -z "${GRAYLOG_HTTP_ENABLE_TLS}" ]]
-	then
+then
 	http_enable_tls="${GRAYLOG_HTTP_ENABLE_TLS}"
 fi
 
@@ -53,10 +53,10 @@ fi
 # otherwise HTTP_BIND_ADDRESS
 
 if [[ ! -z "${http_publish_uri}" ]]
-	then
+then
 	check_url="${proto}"://"${http_publish_uri}"
 elif [[ ! -z "${http_bind_address}" ]]
-	then
+then
 	check_url="${proto}"://"${http_bind_address}"
 else
 	echo "not possible to get Graylog listen URI - abort"
@@ -65,7 +65,7 @@ fi
 
 
 if curl --silent --fail "${check_url}"/api
-	then
+then
   	exit 0
 fi
 exit 1


### PR DESCRIPTION
reworked the health_check that should now work in all conditions. 

The only uncovered case is when someone gives HTTP_PUBLISH_URI a wildcard address what will make Graylog take a "the first" interface. IMHO that should not happen in Docker environments.

FIX: https://github.com/Graylog2/graylog-docker/issues/57