### PR TITLE
update graylog tarball and hash location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     --location \
     --retry 3 \
     --output "/tmp/graylog-${GRAYLOG_VERSION}.tgz" \
-    "https://packages.graylog2.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz"
+    "https://downloads.graylog.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz"
 
 RUN \
   curl \
@@ -29,7 +29,7 @@ RUN \
     --location \
     --retry 3 \
     --output "/tmp/graylog-${GRAYLOG_VERSION}.tgz.sha256.txt" \
-    "https://packages.graylog2.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz.sha256.txt"
+    "https://downloads.graylog.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz.sha256.txt"
 
 RUN \
   sha256sum --check "graylog-${GRAYLOG_VERSION}.tgz.sha256.txt"
@@ -147,3 +147,4 @@ LABEL maintainer="Graylog, Inc. <hello@graylog.com>" \
       org.label-schema.build-date=${BUILD_DATE} \
       com.microscaling.docker.dockerfile="/Dockerfile" \
       com.microscaling.license="Apache 2.0"
+


### PR DESCRIPTION
I cloned the 3.0 branch and was having issues building the Docker image. It seems the location of the graylog release and sha256 hash has changed.

[Relevant community post](https://community.graylog.org/t/error-when-building-the-docker-image/10181)

Changing the URL allowed me to properly build the image