### PR TITLE
Updating JAVA_HOME in Dockerfile. (for `3.0`)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ WORKDIR ${GRAYLOG_HOME}
 
 # hadolint ignore=DL3008,DL3014,SC2086
 RUN \
-  echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre" > /etc/profile.d/graylog.sh && \
+  echo "export JAVA_HOME=/usr/local/openjdk-8"     > /etc/profile.d/graylog.sh && \
   echo "export BUILD_DATE=${BUILD_DATE}"           >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_VERSION=${GRAYLOG_VERSION}" >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_SERVER_JAVA_OPTS='-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow'" >> /etc/profile.d/graylog.sh && \


### PR DESCRIPTION
Before this change, any attempt to run the docker image lead to:

```
/docker-entrypoint.sh: line 59: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java: No such file or directory
```

For unknown reasons, the jre installation prefix of the
`openjdk:8-jre-slim` image has changed. This PR is updating it, making
the image functional again.