### PR TITLE
Update health_check.sh

### DIFF
--- a/health_check.sh
+++ b/health_check.sh
@@ -65,9 +65,6 @@ fi
 if [[ ! -z "${http_publish_uri}" ]]
 then
 	check_url="${proto}"://"${http_publish_uri}"
-else
-	echo "not possible to get Graylog listen URI - abort"
-	exit 1
 fi
 
 


### PR DESCRIPTION
proposed fix for https://github.com/Graylog2/graylog-docker/issues/98 and remove the else. We do not need the `else` in this as it is set or not.

FIXES https://github.com/Graylog2/graylog-docker/issues/98