### PR TITLE
multiple fixes for health check and added feature

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,6 +61,17 @@ then
  fi
 fi
 
+# check if we are inside a nomad cluster
+# First member is having alloc-index 0, so
+if [[ ! -z "${NOMAD_ALLOC_INDEX}" ]]; then
+  if [ ${NOMAD_ALLOC_INDEX} == 0 ]; then
+    export GRAYLOG_IS_MASTER="true"
+  else
+    export GRAYLOG_IS_MASTER="false"
+  fi
+fi
+
+
 setup() {
   # Create data directories
   for d in journal log plugin config contentpacks

--- a/health_check.sh
+++ b/health_check.sh
@@ -21,6 +21,24 @@ then
 	http_publish_uri=$(grep "^http_publish_uri" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
 	http_bind_address=$(grep "^http_bind_address" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
 	http_enable_tls=$(grep "^http_enable_tls" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+
+	# FIX https://github.com/Graylog2/graylog-docker/issues/102
+	# This will remove the protocol from the URI if set via 
+	# configuration. 
+	# not the smartest solution currently but a working
+	# TODO: find a better way or maybe write a function
+	if [[ ! -z ${http_publish_uri} ]]
+	then
+		# remove the protocol from the URI
+		proton="$(echo "${http_publish_uri}" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+		url=$(echo "${http_publish_uri}" | sed -e s,"$proton",,g)
+		# we want to be sure to use https if enable
+		# currently this looks like the best solution to cut
+		# the protocoll away and set it based on 
+		# the fact if TLS is enabled or not
+		http_publish_uri="${url}"
+	fi
+
 fi
 
 # try to get the data from environment variables

--- a/health_check.sh
+++ b/health_check.sh
@@ -78,4 +78,15 @@ if curl --silent --fail "${check_url}"/api
 then
   	exit 0
 fi
+
+# FIX https://github.com/Graylog2/graylog-docker/issues/101
+# When the above check fails fall back to localhost 
+# This is not the most elegant solution but a working one
+if curl --silent --fail http://127.0.0.1/api
+then
+  	exit 0
+fi
+
+
+
 exit 1

--- a/health_check.sh
+++ b/health_check.sh
@@ -27,6 +27,7 @@ then
 	# configuration. 
 	# not the smartest solution currently but a working
 	# TODO: find a better way or maybe write a function
+	# shellcheck disable=SC2001
 	if [[ ! -z ${http_publish_uri} ]]
 	then
 		# remove the protocol from the URI


### PR DESCRIPTION
This added the feature to auto set master in a nomad cluster - similar to the kubernetes one - this will also be documented.
CLOSE: https://github.com/Graylog2/graylog-docker/issues/103



It will fix two bugs with the docker health check.  The first was introduced because the protocol was not removed when the `http_publish_uri` was set in a configuration file, but if set via environment variable it was cleaned. At last the protocol was added again and if it was set via configuration the result was a 
double protocol
FIX: https://github.com/Graylog2/graylog-docker/issues/102


According to the issue ( https://github.com/Graylog2/graylog-docker/issues/101 ) when the container runs in docker swarm it runs into the problem that the `http_publish_uri` might not be reachable for the container. What should not happen, but could. To fix this I introduced a second that if the first fails to localhost what can be seen as a fix for many similar situation. If that also fails the `healtch_check` will fail anyway. 
FIX: https://github.com/Graylog2/graylog-docker/issues/101
