### PR TITLE
Added libx11-6 libnss3 packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,8 @@ RUN \
     tini \
     libcap2-bin \
     libglib2.0-0 \
+    libx11-6 \
+    libnss3 \
     fontconfig > /dev/null && \
   addgroup \
     --gid "${GRAYLOG_GID}" \


### PR DESCRIPTION
I added the packages libx11-6 and libnss3 because without them the chromedriver for the enterprise reporting plugin is not going to work. I think having them in the docker container would be quite nice.