### PR TITLE
Check for existing protocol in http_publish_uri

### DIFF
--- a/health_check.sh
+++ b/health_check.sh
@@ -83,7 +83,12 @@ fi
 
 if [[ ! -z "${http_publish_uri}" ]]
 then
-	check_url="${proto}"://"${http_publish_uri}"
+	if [[ "${http_publish_uri}" =~ ^[[:alnum:]]+://.+ ]]
+	then
+		check_url="${http_publish_uri}"
+	else
+		check_url="${proto}"://"${http_publish_uri}"
+	fi
 fi
 
 if [[ -z "${check_url}" ]]


### PR DESCRIPTION
The Graylog docs indicate that http_publish_uri should include the protocol. This adds a simple check to ensure that we don't specify it twice in check_url.

This is a significant issue in a situation where HTTPS is being handled by a reverse proxy rather than directly by Graylog.