### PR TITLE
Remove the MicroBadger badge from 'README.md'. 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 Latest stable version of Graylog is *4.1.3* this Version is available with the tags `4.1` or `4.1.3-1`.
 
-[![Image Version](https://img.shields.io/badge/version-4.0-blue)][microbadger]  [![Docker Stars](https://img.shields.io/docker/stars/graylog/graylog.svg)][hub] [![Docker Pulls](https://img.shields.io/docker/pulls/graylog/graylog.svg)][hub]
+[![Docker Stars](https://img.shields.io/docker/stars/graylog/graylog.svg)][hub] [![Docker Pulls](https://img.shields.io/docker/pulls/graylog/graylog.svg)][hub]
 
 [hub]: https://hub.docker.com/r/graylog/graylog/
-[microbadger]: https://microbadger.com/images/graylog/graylog
 
 Use the stable `4.1` release for your production environments. Please check the [latest stable documentation](http://docs.graylog.org/en/4.0/pages/installation/docker.html) for complete installation and configuration instruction.
 


### PR DESCRIPTION
MicroBadger has been down since July 1st, 2021.

https://web.archive.org/web/20210409135814/https://microbadger.com/shutdown
https://github.com/microscaling/microbadger/issues/75

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

