### PR TITLE
Ensure bash passes SIGTERM to java. 

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -93,7 +93,7 @@ setup() {
 
 graylog() {
 
-  "${JAVA_HOME}/bin/java" \
+  exec "${JAVA_HOME}/bin/java" \
     ${GRAYLOG_SERVER_JAVA_OPTS} \
     -jar \
     -Dlog4j.configurationFile="${GRAYLOG_HOME}/data/config/log4j2.xml" \

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -ux
 
 GRAYLOG_PORT=9000
 

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -219,7 +219,7 @@ create_input_streams() {
     jq --raw-output '.message' input_plaintext_result.json 2> /dev/null
   fi
 
-  sleep 2
+  sleep 5
 }
 
 send_messages() {

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -233,7 +233,7 @@ send_messages() {
   # Send message to Syslog TCP input
   echo '<0>1 2018-07-04T12:00:00.000Z test.example.com test - - - syslog' | nc -w5 127.0.0.1 514
 
-  sleep 2s
+  sleep 5s
 }
 
 validate_messages() {


### PR DESCRIPTION
This ensures that Graylog shuts down properly when `docker stop` is run. 

Fixes #173 