### PR TITLE
Bump from Debian Buster (old stable) to Bullseye (current stable)

### DIFF
--- a/docker/enterprise/Dockerfile
+++ b/docker/enterprise/Dockerfile
@@ -1,7 +1,7 @@
 ARG JAVA_VERSION_MAJOR=8
 
 # layer for download and verifying
-FROM debian:buster-slim as graylog-downloader
+FROM debian:bullseye-slim as graylog-downloader
 
 ARG VCS_REF
 ARG BUILD_DATE
@@ -90,7 +90,7 @@ RUN \
 #
 # final layer
 # use the smallest debian with headless openjdk and copying files from download layers
-FROM openjdk:${JAVA_VERSION_MAJOR}-jre-slim-buster
+FROM openjdk:${JAVA_VERSION_MAJOR}-jre-slim-bullseye
 
 ARG VCS_REF
 ARG GRAYLOG_VERSION

--- a/docker/forwarder/Dockerfile
+++ b/docker/forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim-buster
+FROM openjdk:8-jre-slim-bullseye
 
 ARG VCS_REF
 ARG BUILD_DATE

--- a/docker/oss/Dockerfile
+++ b/docker/oss/Dockerfile
@@ -1,7 +1,7 @@
 ARG JAVA_VERSION_MAJOR=8
 
 # layer for download and verifying
-FROM debian:buster-slim as graylog-downloader
+FROM debian:bullseye-slim as graylog-downloader
 
 ARG VCS_REF
 ARG GRAYLOG_VERSION
@@ -63,7 +63,7 @@ RUN \
 #
 # final layer
 # use the smallest debian with headless openjdk and copying files from download layers
-FROM openjdk:${JAVA_VERSION_MAJOR}-jre-slim-buster
+FROM openjdk:${JAVA_VERSION_MAJOR}-jre-slim-bullseye
 
 ARG VCS_REF
 ARG GRAYLOG_VERSION


### PR DESCRIPTION
https://wiki.debian.org/DebianBullseye
https://wiki.debian.org/DebianReleases#Production_Releases

No particular reason for this, aside from using the latest and greatest and adding ~2 years of Debian support.  `make integration_test` passes.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging