### PR TITLE
Add new release pipeline.

### DIFF
--- a/README.j2
+++ b/README.j2
@@ -21,10 +21,8 @@ This is the open source [Graylog ](https://hub.docker.com/r/graylog/graylog/) im
 
 | Java Version  | Platform  | Tags  |
 |---|---|---|
+| OpenJDK 8  | `linux/amd64`, `linux/arm64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}` |
 | OpenJDK 11  | `linux/amd64`, `linux/arm64`  | `{{ graylog.major_version }}.{{ graylog.minor_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}-jre11`  |
-| OpenJDK 8  | `linux/amd64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}` |
-| OpenJDK 8  | `linux/arm64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}-arm64`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-arm64`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}-arm64` |
-
 
 > Note: There is no 'latest' tag. You'll need to specify which version you want.
 
@@ -34,9 +32,8 @@ This is the [Graylog Enterprise](https://hub.docker.com/r/graylog/graylog-enterp
 
 | Java Version  | Platform  | Tags  |
 |---|---|---|
-| OpenJDK 11  | `linux/amd64`, `linux/arm64`  | `{{ graylog.major_version }}.{{ graylog.minor_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}-jre11`  |
 | OpenJDK 8  | `linux/amd64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}` |
-| OpenJDK 8  | `linux/arm64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}-arm64`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-arm64`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}-arm64` |
+| OpenJDK 11  | `linux/amd64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}-jre11`  |
 
 
 #### `graylog/graylog-forwarder`
@@ -47,7 +44,7 @@ The latest stable version is **`{{ forwarder.version }}`**, with support for Jav
 
 | Java Version  | Platform  | Tags  |
 |---|---|---|
-| OpenJDK 8 | `linux/amd64` | `{{ forwarder.version }}`, `forwarder-{{ forwarder.version }}-{{ forwarder.release }}` |
+| OpenJDK 8 | `linux/amd64`, `linux/arm64` | `{{ forwarder.version }}`, `forwarder-{{ forwarder.version }}-{{ forwarder.release }}` |
 
 
 ## Architecture

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -6,25 +6,218 @@ pipeline
    {
       buildDiscarder logRotator(artifactDaysToKeepStr: '90', artifactNumToKeepStr: '100', daysToKeepStr: '90', numToKeepStr: '100')
       timestamps()
-      timeout(time: 1, unit: 'HOURS') 
+      timeout(time: 1, unit: 'HOURS')
    }
 
    stages
    {
       stage('Build Docker Image')
       {
+         when
+         {
+           not
+           {
+            buildingTag()
+           }
+         }
          steps
          {
             sh 'make docker_build'
          }
       }
-
       stage('Linter and Integration Test')
       {
+         when
+         {
+           not
+           {
+            buildingTag()
+           }
+         }
          steps
          {
             sh 'make test'
          }
       }
+      stage('Deploy image')
+      {
+        when
+        {
+          buildingTag()
+        }
+
+        steps
+        {
+          echo "TAG_NAME: ${TAG_NAME}"
+
+          script
+          {
+            if (TAG_NAME =~ /^(?:[4-9]|\\d{2,}).[0-9]+.[0-9]+-(?:[0-9]+|alpha|beta|rc).*/)
+            {
+              PARSED_VERSION = parse_version(TAG_NAME)
+              MAJOR = PARSED_VERSION[0]
+              MINOR = PARSED_VERSION[1]
+              PATCH = PARSED_VERSION[2]
+              echo "MAJOR: ${MAJOR}"
+              echo "MINOR: ${MINOR}"
+              echo "PATCH: ${PATCH}"
+
+              //Is the revision suffix just a number?
+              if (TAG_NAME =~ /^([4-9]|\d{2,}).([0-9]+).([0-9]+)-([0-9]+)$/)
+              {
+                TAG_ARGS                  = """--tag graylog/graylog:${env.TAG_NAME} \
+                                            --tag graylog/graylog:${MAJOR}.${MINOR}.${PATCH} \
+                                            --tag graylog/graylog:${MAJOR}.${MINOR}"""
+
+                TAG_ARGS_ENTERPRISE       = """--tag graylog/graylog-enterprise:${env.TAG_NAME} \
+                                             --tag graylog/graylog-enterprise:${MAJOR}.${MINOR}.${PATCH} \
+                                             --tag graylog/graylog-enterprise:${MAJOR}.${MINOR}"""
+                TAG_ARGS_JRE11            = """--tag graylog/graylog:${env.TAG_NAME}-jre11 \
+                                             --tag graylog/graylog:${MAJOR}.${MINOR}.${PATCH}-jre11 \
+                                             --tag graylog/graylog:${MAJOR}.${MINOR}-jre11"""
+                TAG_ARGS_JRE11_ENTERPRISE = """--tag graylog/graylog-enterprise:${env.TAG_NAME}-jre11 \
+                                               --tag graylog/graylog-enterprise:${MAJOR}.${MINOR}.${PATCH}-jre11 \
+                                               --tag graylog/graylog-enterprise:${MAJOR}.${MINOR}-jre11"""
+
+              }
+              else
+              {
+                //This is an alpha/beta/rc release, so don't update the version tags
+                TAG_ARGS                  = "--tag graylog/graylog:${env.TAG_NAME}"
+                TAG_ARGS_ENTERPRISE       = "--tag graylog/graylog-enterprise:${env.TAG_NAME}"
+                TAG_ARGS_JRE11            = "--tag graylog/graylog:${env.TAG_NAME}-jre11"
+                TAG_ARGS_JRE11_ENTERPRISE = "--tag graylog/graylog-enterprise:${env.TAG_NAME}-jre11"
+              }
+
+              docker.withRegistry('', 'docker-hub')
+              {
+                sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
+                sh 'docker buildx create --name multiarch --driver docker-container --use | true'
+                sh 'docker buildx inspect --bootstrap'
+                sh """
+                    docker buildx build \
+                      --platform linux/amd64,linux/arm64/v8 \
+                      --no-cache \
+                      --build-arg GRAYLOG_VERSION=\$(./release.py --get-graylog-version) \
+                      --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
+                      ${TAG_ARGS} \
+                      --file docker/oss/Dockerfile \
+                      --push \
+                      .
+                """
+
+                sh """
+                    docker buildx build \
+                      --platform linux/amd64 \
+                      --no-cache \
+                      --build-arg GRAYLOG_VERSION=\$(./release.py --get-graylog-version) \
+                      --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
+                      ${TAG_ARGS_ENTERPRISE} \
+                      --file docker/enterprise/Dockerfile \
+                      --push \
+                      .
+                """
+
+                sh """
+                    docker buildx build \
+                      --platform linux/amd64,linux/arm64/v8 \
+                      --no-cache \
+                      --build-arg GRAYLOG_VERSION=\$(./release.py --get-graylog-version) \
+                      --build-arg JAVA_VERSION_MAJOR=11 \
+                      --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
+                      ${TAG_ARGS_JRE11} \
+                      --file docker/oss/Dockerfile \
+                      --push \
+                      .
+                """
+
+                sh """
+                  docker buildx build \
+                    --platform linux/amd64 \
+                    --no-cache \
+                    --build-arg GRAYLOG_VERSION=\$(./release.py --get-graylog-version) \
+                    --build-arg JAVA_VERSION_MAJOR=11 \
+                    --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
+                    ${TAG_ARGS_JRE11_ENTERPRISE} \
+                    --file docker/enterprise/Dockerfile \
+                    --push \
+                    .
+                """
+              }
+            }
+
+            if (TAG_NAME =~ /forwarder-.*/)
+            {
+              PARSED_VERSION = parse_forwarder_version(TAG_NAME)
+              MAJOR = PARSED_VERSION[0]
+              MINOR = PARSED_VERSION[1]
+              PATCH = PARSED_VERSION[2]
+              echo "MAJOR: ${MAJOR}"
+              echo "MINOR: ${MINOR}"
+              echo "PATCH: ${PATCH}"
+
+              docker.withRegistry('', 'docker-hub')
+              {
+                sh """
+                  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                  docker buildx create --name multiarch --driver docker-container --use | true
+                  docker buildx inspect --bootstrap
+                  docker buildx build \
+                    --platform linux/amd64,linux/arm64/v8 \
+                    --no-cache \
+                    --build-arg GRAYLOG_FORWARDER_PACKAGE_VERSION=\$(./release.py --get-forwarder-version) \
+                    --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
+                    --tag graylog/graylog-forwarder:${env.TAG_NAME}-arm64 \
+                    --tag graylog/graylog-forwarder:${MAJOR}.${MINOR}-arm64 \
+                    --file docker/forwarder/Dockerfile \
+                    --push \
+                    .
+                """
+              }
+
+            }
+          }
+        }
+      }
    }
+}
+
+// Parse a string containing a semantic version
+def parse_version(version)
+{
+  if (version)
+  {
+    def pattern = /^([4-9]|\d\{2,\}+).([0-9]+).([0-9]+)-?.*$/
+    def matcher = java.util.regex.Pattern.compile(pattern).matcher(version)
+
+    if (matcher.find()) {
+      return [matcher.group(1), matcher.group(2), matcher.group(3)]
+    } else {
+      return null
+    }
+  }
+  else
+  {
+    return null
+  }
+}
+
+// Parse a string containing the forwarder version
+def parse_forwarder_version(version)
+{
+  if (version)
+  {
+    def pattern = /^forwarder-([0-9]+).([0-9]+)-([0-9]+)$/
+    def matcher = java.util.regex.Pattern.compile(pattern).matcher(version)
+
+    if (matcher.find()) {
+      return [matcher.group(1), matcher.group(2), matcher.group(3)]
+    } else {
+      return null
+    }
+  }
+  else
+  {
+    return null
+  }
 }


### PR DESCRIPTION
Add the multiarch image pipeline to the `4.0` branch. 

This ensures that if we release a bugfix for `4.0`, the release pipeline will work in Jenkins. 
