### PR TITLE
Reduce image size by removing large cross platform chromedriver binaries

### DIFF
--- a/docker/enterprise/Dockerfile
+++ b/docker/enterprise/Dockerfile
@@ -10,6 +10,7 @@ ARG LOCAL_BUILD_TGZ
 ARG GRAYLOG_HOME=/usr/share/graylog
 ARG GRAYLOG_UID=1100
 ARG GRAYLOG_GID=1100
+ARG TARGETPLATFORM
 
 WORKDIR /tmp
 
@@ -42,6 +43,13 @@ RUN if [ "${LOCAL_BUILD_TGZ}" ]; then \
         tar --extract --gzip --file "/tmp/graylog.tgz" --strip-components=1 --directory /opt/graylog; \
     fi
 
+# Reduce image size by removing large cross platform chromedriver binaries
+RUN if [ "${TARGETPLATFORM}" != "linux/arm64" ]; then \
+        rm /opt/graylog/bin/*_arm64; \
+    fi
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        rm /opt/graylog/bin/*_amd64; \
+    fi
 
 RUN \
   install \


### PR DESCRIPTION
The amd64 image does not need the arm64 chromdriver binaries
and vice versa.

This reduces the image by ~300 MB

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

