### PR TITLE
Always pull referenced images on build

### DIFF
--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -139,6 +139,7 @@ pipeline
                         --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
                         ${TAG_ARGS_ENTERPRISE} \
                         --file docker/enterprise/Dockerfile \
+                        --pull \
                         .
                         docker push graylog/graylog-enterprise:${env.TAG_NAME}
                         docker push graylog/graylog-enterprise:${MAJOR}.${MINOR}.${PATCH}
@@ -190,6 +191,7 @@ pipeline
                       --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
                       ${TAG_ARGS_JRE11_ENTERPRISE} \
                       --file docker/enterprise/Dockerfile \
+                      --pull \
                       .
                       docker push graylog/graylog-enterprise:${env.TAG_NAME}-jre11
                       docker push graylog/graylog-enterprise:${MAJOR}.${MINOR}.${PATCH}-jre11

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -106,6 +106,7 @@ pipeline
                       --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
                       ${TAG_ARGS} \
                       --file docker/oss/Dockerfile \
+                      --pull \
                       --push \
                       .
                 """
@@ -121,6 +122,7 @@ pipeline
                         --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
                         ${TAG_ARGS_ENTERPRISE} \
                         --file docker/enterprise/Dockerfile \
+                        --pull \
                         --push \
                         .
                   """
@@ -153,6 +155,7 @@ pipeline
                       --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
                       ${TAG_ARGS_JRE11} \
                       --file docker/oss/Dockerfile \
+                      --pull \
                       --push \
                       .
                 """
@@ -169,6 +172,7 @@ pipeline
                       --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
                       ${TAG_ARGS_JRE11_ENTERPRISE} \
                       --file docker/enterprise/Dockerfile \
+                      --pull \
                       --push \
                       .
                   """
@@ -230,6 +234,7 @@ pipeline
                     --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
                     ${TAG_ARGS} \
                     --file docker/forwarder/Dockerfile \
+                    --pull \
                     --push \
                     .
                 """


### PR DESCRIPTION
Otherwise, we might build new images with old base images.

**Note:** This should be backported to the 4.2, 4.1, and 4.0 branches.