### PR TITLE
fix: skip unreadable files in mounted plugins dir

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -80,10 +80,15 @@ if [[ ! -z "${NOMAD_ALLOC_INDEX}" ]]; then
 fi
 
 # Merge plugin dirs to allow mounting of /plugin as a volume
-export GRAYLOG_PLUGIN_DIR=/usr/share/graylog/plugins-merged
-rm -f /usr/share/graylog/plugins-merged/*
-find /usr/share/graylog/plugins-default/ -type f -exec cp {} /usr/share/graylog/plugins-merged/ \;
-find /usr/share/graylog/plugin/ -type f -exec cp {} /usr/share/graylog/plugins-merged/ \;
+export GRAYLOG_PLUGIN_DIR=${GRAYLOG_HOME}/plugins-merged
+rm -f ${GRAYLOG_HOME}/plugins-merged/*
+find ${GRAYLOG_HOME}/plugins-default/ -type f -exec cp {} ${GRAYLOG_HOME}/plugins-merged/ \;
+for f in ${GRAYLOG_HOME}/plugin/*
+do
+  if [[ -f $f ]]; then
+    cp -t ${GRAYLOG_HOME}/plugins-merged/ ${f}
+  fi
+done
 
 
 setup() {


### PR DESCRIPTION
I tried my hardest to keep it a simple one-liner but `find` really does not like dealing with files without `x` permissions, so I gave in and went with a simple for loop.

Tested locally and my issue in #206 was resolved: a mounted directory with a `lost+found` dir with perms of `700` no longer prevented the container from starting, and a plugin next to that `lost+found` dir was successfully placed into `plugins-merged` and owned by `graylog:graylog`.

Closes #206 

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

