### PR TITLE
Switch from `openjdk` to `eclipse-temurin` for base images. (4.3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,3 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: openjdk
-    versions:
-    - ">= 11.pre.jre.pre.slim.a"
-    - "< 12"

--- a/README.j2
+++ b/README.j2
@@ -13,7 +13,7 @@ Graylog is a centralized logging solution that enables aggregating and searching
 
 ## Image Details
 
-There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images run on Debian 11.
+There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
 
 #### `graylog/graylog`
 

--- a/README.j2
+++ b/README.j2
@@ -15,6 +15,8 @@ Graylog is a centralized logging solution that enables aggregating and searching
 
 There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
 
+> Note: Images released prior to July 2022 were based on variants of the now-deprecated [`openjdk` image](https://hub.docker.com/_/openjdk).
+
 #### `graylog/graylog`
 
 This is the open source [Graylog ](https://hub.docker.com/r/graylog/graylog/) image. It contains [Graylog](https://github.com/Graylog2/graylog2-server) as well as the [Integrations](https://docs.graylog.org/docs/integrations) plugin.

--- a/README.j2
+++ b/README.j2
@@ -15,7 +15,7 @@ Graylog is a centralized logging solution that enables aggregating and searching
 
 There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
 
-> Note: Images released prior to July 2022 were based on variants of the now-deprecated [`openjdk` image](https://hub.docker.com/_/openjdk).
+> Note: Images released prior to August 2022 were based on variants of the now-deprecated [`openjdk` image](https://hub.docker.com/_/openjdk).
 
 #### `graylog/graylog`
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Graylog is a centralized logging solution that enables aggregating and searching
 
 ## Image Details
 
-There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images run on Debian 11.
+There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
 
 #### `graylog/graylog`
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Graylog is a centralized logging solution that enables aggregating and searching
 
 There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
 
+> Note: Images released prior to July 2022 were based on variants of the now-deprecated [`openjdk` image](https://hub.docker.com/_/openjdk).
+
 #### `graylog/graylog`
 
 This is the open source [Graylog ](https://hub.docker.com/r/graylog/graylog/) image. It contains [Graylog](https://github.com/Graylog2/graylog2-server) as well as the [Integrations](https://docs.graylog.org/docs/integrations) plugin.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Graylog is a centralized logging solution that enables aggregating and searching
 
 There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
 
-> Note: Images released prior to July 2022 were based on variants of the now-deprecated [`openjdk` image](https://hub.docker.com/_/openjdk).
+> Note: Images released prior to August 2022 were based on variants of the now-deprecated [`openjdk` image](https://hub.docker.com/_/openjdk).
 
 #### `graylog/graylog`
 

--- a/docker/enterprise/Dockerfile
+++ b/docker/enterprise/Dockerfile
@@ -126,6 +126,10 @@ RUN \
     --quiet \
     "${GRAYLOG_USER}" && \
   setcap 'cap_net_bind_service=+ep' "${JAVA_HOME}/bin/java" && \
+  # https://github.com/docker-library/openjdk/blob/da594d91b0364d5f1a32e0ce6b4d3fd8a9116844/8/jdk/slim-bullseye/Dockerfile#L105
+  # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
+  find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf && \
+  ldconfig && \
   apt-get remove --assume-yes --purge \
     apt-utils > /dev/null && \
   rm -f /etc/apt/sources.list.d/* && \

--- a/docker/enterprise/Dockerfile
+++ b/docker/enterprise/Dockerfile
@@ -1,7 +1,7 @@
 ARG JAVA_VERSION_MAJOR=8
 
 # layer for download and verifying
-FROM debian:bullseye-slim as graylog-downloader
+FROM ubuntu:jammy as graylog-downloader
 
 ARG VCS_REF
 ARG BUILD_DATE
@@ -74,8 +74,7 @@ COPY config ${GRAYLOG_HOME}/data/config
 # -------------------------------------------------------------------------------------------------
 #
 # final layer
-# use the smallest debian with headless openjdk and copying files from download layers
-FROM openjdk:${JAVA_VERSION_MAJOR}-jre-slim-bullseye
+FROM eclipse-temurin:${JAVA_VERSION_MAJOR}-jre-jammy
 
 ARG VCS_REF
 ARG GRAYLOG_VERSION
@@ -93,7 +92,6 @@ WORKDIR ${GRAYLOG_HOME}
 
 # hadolint ignore=DL3027,DL3008
 RUN \
-  echo "export JAVA_HOME=/usr/local/openjdk-${JAVA_VERSION_MAJOR}"     > /etc/profile.d/graylog.sh && \
   echo "export BUILD_DATE=${BUILD_DATE}"           >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_VERSION=${GRAYLOG_VERSION}" >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_SERVER_JAVA_OPTS='-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow'" >> /etc/profile.d/graylog.sh && \

--- a/docker/forwarder/Dockerfile
+++ b/docker/forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim-bullseye
+FROM eclipse-temurin:8-jre-jammy
 
 ARG VCS_REF
 ARG BUILD_DATE

--- a/docker/oss/Dockerfile
+++ b/docker/oss/Dockerfile
@@ -1,7 +1,7 @@
 ARG JAVA_VERSION_MAJOR=8
 
 # layer for download and verifying
-FROM debian:bullseye-slim as graylog-downloader
+FROM ubuntu:jammy as graylog-downloader
 
 ARG VCS_REF
 ARG GRAYLOG_VERSION
@@ -49,8 +49,7 @@ COPY config ${GRAYLOG_HOME}/data/config
 # -------------------------------------------------------------------------------------------------
 #
 # final layer
-# use the smallest debian with headless openjdk and copying files from download layers
-FROM openjdk:${JAVA_VERSION_MAJOR}-jre-slim-bullseye
+FROM eclipse-temurin:${JAVA_VERSION_MAJOR}-jre-jammy
 
 ARG VCS_REF
 ARG GRAYLOG_VERSION
@@ -68,7 +67,6 @@ WORKDIR ${GRAYLOG_HOME}
 
 # hadolint ignore=DL3027,DL3008
 RUN \
-  echo "export JAVA_HOME=/usr/local/openjdk-${JAVA_VERSION_MAJOR}"     > /etc/profile.d/graylog.sh && \
   echo "export BUILD_DATE=${BUILD_DATE}"           >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_VERSION=${GRAYLOG_VERSION}" >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_SERVER_JAVA_OPTS='-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow'" >> /etc/profile.d/graylog.sh && \

--- a/docker/oss/Dockerfile
+++ b/docker/oss/Dockerfile
@@ -101,6 +101,10 @@ RUN \
     --quiet \
     "${GRAYLOG_USER}" && \
   setcap 'cap_net_bind_service=+ep' "${JAVA_HOME}/bin/java" && \
+  # https://github.com/docker-library/openjdk/blob/da594d91b0364d5f1a32e0ce6b4d3fd8a9116844/8/jdk/slim-bullseye/Dockerfile#L105
+  # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
+  find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf && \
+  ldconfig && \
   apt-get remove --assume-yes --purge \
     apt-utils > /dev/null && \
   rm -f /etc/apt/sources.list.d/* && \


### PR DESCRIPTION
The `openjdk` images are being retired/discontinued.  Since Eclipse Temurin (AdoptOpenJDK) was previously selected for other Graylog uses, it seems like a good pick for the official Graylog images.

Ubuntu Jammy, selected as the OS variant here (and by the Temurin project for non-specific tags; [available options](https://github.com/adoptium/containers/tree/main/11/jre)), will have standard support until April 2027.

Refs:
* https://github.com/docker-library/openjdk/issues/505
* https://github.com/Graylog2/graylog2-server/issues/11467
* https://github.com/Graylog2/graylog2-server/blob/bf001c5a039380e0afadc9f570d070d2b70ee578/.github/workflows/build.yml#L18