### PR TITLE
Assume Docker Compose v2 if `docker-compose` is missing in integration test

### DIFF
--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -30,6 +30,13 @@ trap finish SIGINT SIGTERM INT TERM EXIT
 # -------------------------------------------------------------------------------------------------
 
 
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  docker-compose() {
+    docker compose "$@"
+  }
+fi
+
 JQ_VERSION='1.6'
 JQ_PATH='/usr/local/bin/jq'
 if ! [ -x "$(command -v jq)" ]; then

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -31,7 +31,7 @@ trap finish SIGINT SIGTERM INT TERM EXIT
 
 
 
-if ! [ -x "$(command -v docker-compose)" ]; then
+if ! command -v docker-compose; then
   docker-compose() {
     docker compose "$@"
   }


### PR DESCRIPTION
If `docker-compose` is not available during integration testing, assume Docker Compose v2 (`docker compose` by default) is to be used.

https://www.docker.com/blog/announcing-compose-v2-general-availability/

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

