### PR TITLE
Update to Java 17 and retire Java 11 tagged images

### DIFF
--- a/README.j2
+++ b/README.j2
@@ -13,7 +13,7 @@ Graylog is a centralized logging solution that enables aggregating and searching
 
 ## Image Details
 
-There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
+There are several different image variants available, with variants for platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
 
 > Note: Images released prior to August 2022 were based on variants of the now-deprecated [`openjdk` image](https://hub.docker.com/_/openjdk).
 
@@ -23,8 +23,7 @@ This is the open source [Graylog ](https://hub.docker.com/r/graylog/graylog/) im
 
 | Java Version  | Platform  | Tags  |
 |---|---|---|
-| OpenJDK 8  | `linux/amd64`, `linux/arm64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}` |
-| OpenJDK 11  | `linux/amd64`, `linux/arm64`  | `{{ graylog.major_version }}.{{ graylog.minor_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}-jre11`  |
+| OpenJDK 17  | `linux/amd64`, `linux/arm64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}` |
 
 > Note: There is no 'latest' tag. You'll need to specify which version you want.
 
@@ -34,8 +33,7 @@ This is the [Graylog Enterprise](https://hub.docker.com/r/graylog/graylog-enterp
 
 | Java Version  | Platform  | Tags  |
 |---|---|---|
-| OpenJDK 8  | `linux/amd64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}` |
-| OpenJDK 11  | `linux/amd64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-jre11`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}-jre11`  |
+| OpenJDK 17  | `linux/amd64` | `{{ graylog.major_version }}.{{ graylog.minor_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}`, `{{ graylog.major_version }}.{{ graylog.minor_version }}.{{ graylog.patch_version }}-{{ graylog.release }}` |
 
 
 #### `graylog/graylog-forwarder`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [hub]: https://hub.docker.com/r/graylog/graylog/
 
-The latest stable version of Graylog is **`4.3.5`**.
+The latest stable version of Graylog is **`5.0-beta.1.0`**.
 
 ## What is Graylog?
 
@@ -13,7 +13,7 @@ Graylog is a centralized logging solution that enables aggregating and searching
 
 ## Image Details
 
-There are several different image variants available, with variants for Java 8 and 11 on platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
+There are several different image variants available, with variants for platforms `linux/amd64` and `linux/arm64`. All images are based on the latest [Eclipse Temurin image](https://hub.docker.com/_/eclipse-temurin) (JRE + Ubuntu LTS variant) available at build time.
 
 > Note: Images released prior to August 2022 were based on variants of the now-deprecated [`openjdk` image](https://hub.docker.com/_/openjdk).
 
@@ -23,8 +23,7 @@ This is the open source [Graylog ](https://hub.docker.com/r/graylog/graylog/) im
 
 | Java Version  | Platform  | Tags  |
 |---|---|---|
-| OpenJDK 8  | `linux/amd64`, `linux/arm64` | `4.3`, `4.3.5`, `4.3.5-2` |
-| OpenJDK 11  | `linux/amd64`, `linux/arm64`  | `4.3-jre11`, `4.3.5-jre11`, `4.3.5-2-jre11`  |
+| OpenJDK 17  | `linux/amd64`, `linux/arm64` | `5.0-beta.1`, `5.0-beta.1.0`, `5.0-beta.1.0-0` |
 
 > Note: There is no 'latest' tag. You'll need to specify which version you want.
 
@@ -34,8 +33,7 @@ This is the [Graylog Enterprise](https://hub.docker.com/r/graylog/graylog-enterp
 
 | Java Version  | Platform  | Tags  |
 |---|---|---|
-| OpenJDK 8  | `linux/amd64` | `4.3`, `4.3.5`, `4.3.5-2` |
-| OpenJDK 11  | `linux/amd64` | `4.3-jre11`, `4.3.5-jre11`, `4.3.5-2-jre11`  |
+| OpenJDK 17  | `linux/amd64` | `5.0-beta.1`, `5.0-beta.1.0`, `5.0-beta.1.0-0` |
 
 
 #### `graylog/graylog-forwarder`
@@ -46,7 +44,7 @@ The latest stable version is **`4.8`**, with support for Java 8 on platform `lin
 
 | Java Version  | Platform  | Tags  |
 |---|---|---|
-| OpenJDK 8 | `linux/amd64`, `linux/arm64` | `4.8`, `forwarder-4.8-2` |
+| OpenJDK 8 | `linux/amd64`, `linux/arm64` | `4.8`, `forwarder-4.8-1` |
 
 
 ## Architecture
@@ -71,7 +69,7 @@ Notably, this image **requires** that two important configuration options be set
       * The default username is `admin`.  This value is customizable via configuration option `root_username` (environment variable `GRAYLOG_ROOT_USERNAME`).
     * In general, these credentials will only be needed to initially set up the system or reconfigure the system in the event of an authentication backend failure.
     * This password cannot be changed using the API or via the Web interface.
-    * May be generated with something like: `echo -n "Enter Password: " && head -2 </dev/stdin | tr -d '\n' | sha256sum | cut -d" " -f1`
+    * May be generated with something like: `echo -n "Enter Password: " && head -1 </dev/stdin | tr -d '\n' | sha256sum | cut -d" " -f1`
 
 
 Every [Graylog configuration option](https://docs.graylog.org/docs/server-conf) can be set via environment variable. To get the environment variable name for a given configuration option, simply prefix the option name with `GRAYLOG_` and put it all in upper case. Another option is to store the configuration file outside of the container and edit it directly.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,19 +8,6 @@ __GRAYLOG_SERVER_JAVA_OPTS=${GRAYLOG_SERVER_JAVA_OPTS}
 # shellcheck disable=SC1091
 source /etc/profile
 
-#Set default GC
-if [[ -z ${GRAYLOG_DOCKER_DISABLE_CMS_GC} ]]
-then
-  if "${JAVA_HOME}/bin/java" -XX:+PrintFlagsFinal 2>&1 |grep -q UseParNewGC; then
-    GRAYLOG_SERVER_JAVA_OPTS="${GRAYLOG_SERVER_JAVA_OPTS} -XX:+UseParNewGC"
-    export GRAYLOG_SERVER_JAVA_OPTS
-  fi
-  if "${JAVA_HOME}/bin/java" -XX:+PrintFlagsFinal 2>&1 |grep -q UseConcMarkSweepGC; then
-    GRAYLOG_SERVER_JAVA_OPTS="${GRAYLOG_SERVER_JAVA_OPTS} -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
-    export GRAYLOG_SERVER_JAVA_OPTS
-  fi
-fi
-
 # and add the previous saved settings to our defaults
 if [[ ! -z ${__GRAYLOG_SERVER_JAVA_OPTS} ]]
 then

--- a/docker/enterprise/Dockerfile
+++ b/docker/enterprise/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION_MAJOR=8
+ARG JAVA_VERSION_MAJOR=17
 
 # layer for download and verifying
 FROM ubuntu:jammy as graylog-downloader

--- a/docker/enterprise/Dockerfile
+++ b/docker/enterprise/Dockerfile
@@ -95,7 +95,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
   echo "export BUILD_DATE=${BUILD_DATE}"           >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_VERSION=${GRAYLOG_VERSION}" >> /etc/profile.d/graylog.sh && \
-  echo "export GRAYLOG_SERVER_JAVA_OPTS='-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow'" >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_SERVER_JAVA_OPTS='-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:-OmitStackTraceInFastThrow -server'" >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_HOME=${GRAYLOG_HOME}"       >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_USER=${GRAYLOG_USER}"       >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_GROUP=${GRAYLOG_GROUP}"     >> /etc/profile.d/graylog.sh && \

--- a/docker/oss/Dockerfile
+++ b/docker/oss/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION_MAJOR=8
+ARG JAVA_VERSION_MAJOR=17
 
 # layer for download and verifying
 FROM ubuntu:jammy as graylog-downloader

--- a/docker/oss/Dockerfile
+++ b/docker/oss/Dockerfile
@@ -70,7 +70,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
   echo "export BUILD_DATE=${BUILD_DATE}"           >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_VERSION=${GRAYLOG_VERSION}" >> /etc/profile.d/graylog.sh && \
-  echo "export GRAYLOG_SERVER_JAVA_OPTS='-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow'" >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_SERVER_JAVA_OPTS='-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:-OmitStackTraceInFastThrow -server'" >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_HOME=${GRAYLOG_HOME}"       >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_USER=${GRAYLOG_USER}"       >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_GROUP=${GRAYLOG_GROUP}"     >> /etc/profile.d/graylog.sh && \

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -76,21 +76,12 @@ pipeline
                 TAG_ARGS_ENTERPRISE       = """--tag graylog/graylog-enterprise:${env.TAG_NAME} \
                                              --tag graylog/graylog-enterprise:${MAJOR}.${MINOR}.${PATCH} \
                                              --tag graylog/graylog-enterprise:${MAJOR}.${MINOR}"""
-                TAG_ARGS_JRE11            = """--tag graylog/graylog:${env.TAG_NAME}-jre11 \
-                                             --tag graylog/graylog:${MAJOR}.${MINOR}.${PATCH}-jre11 \
-                                             --tag graylog/graylog:${MAJOR}.${MINOR}-jre11"""
-                TAG_ARGS_JRE11_ENTERPRISE = """--tag graylog/graylog-enterprise:${env.TAG_NAME}-jre11 \
-                                               --tag graylog/graylog-enterprise:${MAJOR}.${MINOR}.${PATCH}-jre11 \
-                                               --tag graylog/graylog-enterprise:${MAJOR}.${MINOR}-jre11"""
-
               }
               else
               {
                 //This is an alpha/beta/rc release, so don't update the version tags
                 TAG_ARGS                  = "--tag graylog/graylog:${env.TAG_NAME}"
                 TAG_ARGS_ENTERPRISE       = "--tag graylog/graylog-enterprise:${env.TAG_NAME}"
-                TAG_ARGS_JRE11            = "--tag graylog/graylog:${env.TAG_NAME}-jre11"
-                TAG_ARGS_JRE11_ENTERPRISE = "--tag graylog/graylog-enterprise:${env.TAG_NAME}-jre11"
               }
 
               docker.withRegistry('', 'docker-hub')
@@ -147,57 +138,6 @@ pipeline
                   """
                 }
 
-                sh """
-                    docker buildx build \
-                      --platform linux/amd64,linux/arm64/v8 \
-                      --no-cache \
-                      --build-arg GRAYLOG_VERSION=\$(./release.py --get-graylog-version) \
-                      --build-arg JAVA_VERSION_MAJOR=11 \
-                      --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
-                      ${TAG_ARGS_JRE11} \
-                      --file docker/oss/Dockerfile \
-                      --pull \
-                      --push \
-                      .
-                """
-
-                if (MAJOR_INT >= 4 && MINOR_INT >= 3)
-                {
-                  // Since 4.3 we build multi-platform images for Enterprise
-                  sh """
-                    docker buildx build \
-                      --platform linux/amd64,linux/arm64/v8 \
-                      --no-cache \
-                      --build-arg GRAYLOG_VERSION=\$(./release.py --get-graylog-version) \
-                      --build-arg JAVA_VERSION_MAJOR=11 \
-                      --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
-                      ${TAG_ARGS_JRE11_ENTERPRISE} \
-                      --file docker/enterprise/Dockerfile \
-                      --pull \
-                      --push \
-                      .
-                  """
-                }
-                else
-                {
-                  // Using buildx for a single platform always threw a
-                  // HTTP 401 error during upload so we use build instead.
-                  sh """
-                    docker build \
-                      --platform linux/amd64 \
-                      --no-cache \
-                      --build-arg GRAYLOG_VERSION=\$(./release.py --get-graylog-version) \
-                      --build-arg JAVA_VERSION_MAJOR=11 \
-                      --build-arg BUILD_DATE=\$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") \
-                      ${TAG_ARGS_JRE11_ENTERPRISE} \
-                      --file docker/enterprise/Dockerfile \
-                      --pull \
-                      .
-                      docker push graylog/graylog-enterprise:${env.TAG_NAME}-jre11
-                      docker push graylog/graylog-enterprise:${MAJOR}.${MINOR}.${PATCH}-jre11
-                      docker push graylog/graylog-enterprise:${MAJOR}.${MINOR}-jre11
-                  """
-                }
               }
             }
 

--- a/version.yml
+++ b/version.yml
@@ -1,10 +1,10 @@
 graylog:
-  major_version: 4
-  minor_version: 3
+  major_version: 5
+  minor_version: 0-beta.1
   # For pre-releases: 0-beta.1, 0-rc.1
   # For GA releases:  0
-  patch_version: 5
-  release: 2
+  patch_version: 0
+  release: 0
 forwarder:
   version: 4.8
   release: 1


### PR DESCRIPTION
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

