### PR TITLE
Removing the default es hosts entry so that our autodetection works

### DIFF
--- a/config/graylog.conf
+++ b/config/graylog.conf
@@ -190,7 +190,6 @@ http_bind_address = 0.0.0.0:9000
 #
 # Default: http://127.0.0.1:9200
 #elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
-elasticsearch_hosts = http://elasticsearch:9200
 
 # Maximum number of retries to connect to elasticsearch on boot for the version probe.
 #


### PR DESCRIPTION
currently, we have to explicitly unset (set empty) `GRAYLOG_ELASTICSEARCH_HOSTS: ""` in `docker-compose.yml`or when starting docker containers to make autodetection work. this PR fixes it.

fixes https://github.com/Graylog2/graylog-docker/pull/258

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

