### PR TITLE
Removing -dev from DataNode reference to avoid confusion

### DIFF
--- a/docker/datanode/README.md
+++ b/docker/datanode/README.md
@@ -12,7 +12,7 @@ tbd
 services:
   graylog-datanode:
 #    hostname: "datanode"
-    image: "graylog/graylog-datanode:5.2-dev"
+    image: "graylog/graylog-datanode:5.2"
     depends_on:
       - "mongodb"
     environment:


### PR DESCRIPTION
To avoid future confusion, already point to the release version.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

