### PR TITLE
remove `-np` for data node

### DIFF
--- a/docker/datanode/entrypoint.sh
+++ b/docker/datanode/entrypoint.sh
@@ -86,6 +86,5 @@ chown -R "$GDN_USER":"$GDN_GROUP" "$GRAYLOG_DATANODE_DATA_DIR"
 exec setpriv --reuid="$GDN_USER" --regid="$GDN_GROUP" --init-groups \
 	"${GRAYLOG_DATANODE_BIN_DIR}/graylog-datanode" \
 	datanode \
-	-np \
 	-f "$GDN_CONFIG_FILE" \
 	-ff "$GDN_FEATURE_FLAG_FILE"


### PR DESCRIPTION
## Notes for Reviewers
The pid related command line parameters have been removed for data node.
This fixes the data node entrypoint to not pass the `-np` parameter.

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

