### PR TITLE
Filter unimportant but annoying warning from logs

### DIFF
--- a/config/log4j2.xml
+++ b/config/log4j2.xml
@@ -47,6 +47,9 @@
         <Logger name="org.apache.iceberg.IncrementalFileCleanup" level="warn"/>
         <Logger name="org.apache.iceberg.SnapshotProducer" level="warn"/>
         <Logger name="org.apache.iceberg.SnapshotScan" level="warn"/>
+        <Logger name="org.apache.iceberg.aws.s3.S3InputStream" level="warn">
+            <RegexFilter regex=".*An error occurred while aborting the stream.*" onMatch="DENY" onMismatch="ACCEPT"/>
+        </Logger>
         <Logger name="org.apache.iceberg.metrics.LoggingMetricsReporter" level="warn"/>
         <Root level="warn">
             <AppenderRef ref="STDOUT"/>


### PR DESCRIPTION
On canceling a job in the Data Lake, an unimportant/misleading exception can occur that is printed as a warning and clutters up the log.

see https://github.com/Graylog2/graylog2-server/pull/22308 for the upstream PR