### PR TITLE
Remove "java.library.path" setting for sigar

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,7 +92,6 @@ graylog() {
     ${GRAYLOG_SERVER_JAVA_OPTS} \
     -jar \
     -Dlog4j.configurationFile="${GRAYLOG_HOME}/data/config/log4j2.xml" \
-    -Djava.library.path="${GRAYLOG_HOME}/lib/sigar/" \
     -Dgraylog2.installation_source=docker \
     "${GRAYLOG_HOME}/graylog.jar" \
     "$@" \


### PR DESCRIPTION
We don't use sigar anymore.


