### PR TITLE
Install server and logging config into GRAYLOG_HOME/config

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -75,7 +75,7 @@ find ${GRAYLOG_HOME}/plugin ! -readable -prune -o -type f -a -readable -exec cp 
 
 setup() {
   # Create data directories
-  for d in journal log plugin config contentpacks
+  for d in config contentpacks data journal scripts
   do
     dir=${GRAYLOG_HOME}/data/${d}
     [[ -d "${dir}" ]] || mkdir -p "${dir}"
@@ -109,15 +109,31 @@ setupCertificates() {
 }
 
 graylog() {
+  local log_config="${GRAYLOG_HOME}/config/log4j2.xml"
+  local graylog_config="${GRAYLOG_HOME}/config/graylog.conf"
+  local legacy_log_config="${GRAYLOG_HOME}/data/config/log4j2.xml"
+  local legacy_graylog_config="${GRAYLOG_HOME}/data/config/graylog.conf"
+
+  # Backward compatibility for setups that have existing (and potentially custom)
+  # logging and server configuration files in the data/config directory.
+  # See: https://github.com/Graylog2/docker-compose/issues/99
+  if [ -f "$legacy_log_config" ]; then
+    log_config="$legacy_log_config"
+    echo "WARNING: Using deprecated <$legacy_log_config> file. Switch to <$log_config>!"
+  fi
+  if [ -f "$legacy_graylog_config" ]; then
+    graylog_config="$legacy_graylog_config"
+    echo "WARNING: Using deprecated <$legacy_graylog_config> file. Switch to <$graylog_config>!"
+  fi
 
   exec "${JAVA_HOME}/bin/java" \
     ${GRAYLOG_SERVER_JAVA_OPTS} \
     -jar \
-    -Dlog4j.configurationFile="${GRAYLOG_HOME}/data/config/log4j2.xml" \
+    -Dlog4j.configurationFile="${log_config}" \
     -Dgraylog2.installation_source=docker \
     "${GRAYLOG_HOME}/graylog.jar" \
     "$@" \
-    -f "${GRAYLOG_HOME}/data/config/graylog.conf"
+    -f "${graylog_config}"
 }
 
 run() {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -118,12 +118,12 @@ graylog() {
   # logging and server configuration files in the data/config directory.
   # See: https://github.com/Graylog2/docker-compose/issues/99
   if [ -f "$legacy_log_config" ]; then
-    log_config="$legacy_log_config"
     echo "WARNING: Using deprecated <$legacy_log_config> file. Switch to <$log_config>!"
+    log_config="$legacy_log_config"
   fi
   if [ -f "$legacy_graylog_config" ]; then
-    graylog_config="$legacy_graylog_config"
     echo "WARNING: Using deprecated <$legacy_graylog_config> file. Switch to <$graylog_config>!"
+    graylog_config="$legacy_graylog_config"
   fi
 
   exec "${JAVA_HOME}/bin/java" \

--- a/docker/enterprise/Dockerfile
+++ b/docker/enterprise/Dockerfile
@@ -80,13 +80,15 @@ RUN \
     /opt/graylog/data/data \
     /opt/graylog/data/scripts
 
+# hadolint ignore=DL3059
+RUN install --directory --mode=0750 /opt/graylog/config
 
 RUN mv /opt/graylog ${GRAYLOG_HOME} && chown -R ${GRAYLOG_UID}:${GRAYLOG_GID} ${GRAYLOG_HOME}
 RUN mv ${GRAYLOG_HOME}/plugin ${GRAYLOG_HOME}/plugins-default
 RUN install -d -o "${GRAYLOG_UID}" -g "${GRAYLOG_GID}" -m 0755 ${GRAYLOG_HOME}/plugins-merged && \
     install -d -o "${GRAYLOG_UID}" -g "${GRAYLOG_GID}" -m 0755 ${GRAYLOG_HOME}/plugin
 
-COPY config ${GRAYLOG_HOME}/data/config
+COPY config ${GRAYLOG_HOME}/config
 
 # -------------------------------------------------------------------------------------------------
 #

--- a/docker/oss/Dockerfile
+++ b/docker/oss/Dockerfile
@@ -68,12 +68,15 @@ RUN \
     /opt/graylog/data/plugin \
     /opt/graylog/data/data
 
+# hadolint ignore=DL3059
+RUN install --directory --mode=0750 /opt/graylog/config
+
 RUN mv /opt/graylog ${GRAYLOG_HOME} && chown -R ${GRAYLOG_UID}:${GRAYLOG_GID} ${GRAYLOG_HOME}
 RUN mv ${GRAYLOG_HOME}/plugin ${GRAYLOG_HOME}/plugins-default
 RUN install -d -o "${GRAYLOG_UID}" -g "${GRAYLOG_GID}" -m 0755 ${GRAYLOG_HOME}/plugins-merged && \
     install -d -o "${GRAYLOG_UID}" -g "${GRAYLOG_GID}" -m 0755 ${GRAYLOG_HOME}/plugin
 
-COPY config ${GRAYLOG_HOME}/data/config
+COPY config ${GRAYLOG_HOME}/config
 
 # -------------------------------------------------------------------------------------------------
 #

--- a/health_check.sh
+++ b/health_check.sh
@@ -14,13 +14,23 @@ source /etc/profile
 proto=http
 http_bind_address=127.0.0.1:9000
 
+graylog_config="${GRAYLOG_HOME}/config/graylog.conf"
+legacy_graylog_config="${GRAYLOG_HOME}/data/config/graylog.conf"
+
+# Backward compatibility for setups that have an existing (and potentially custom)
+# server configuration file in the data/config directory.
+# See: https://github.com/Graylog2/docker-compose/issues/99
+if [[ -f "$legacy_graylog_config" ]]; then
+	graylog_config="$legacy_graylog_config"
+fi
+
 # check if configuration file is given and grep for variable
-if [[ -f "${GRAYLOG_HOME}"/data/config/graylog.conf ]]
+if [[ -f "$graylog_config" ]]
 then
 	# try to grep the variable from a mounted configuration
-	http_publish_uri=$(grep "^http_publish_uri" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
-	http_bind_address=$(grep "^http_bind_address" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
-	http_enable_tls=$(grep "^http_enable_tls" "${GRAYLOG_HOME}"/data/config/graylog.conf | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+	http_publish_uri=$(grep "^http_publish_uri" "$graylog_config" | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+	http_bind_address=$(grep "^http_bind_address" "$graylog_config" | awk -F '=' '{print $2}' | awk '{$1=$1};1')
+	http_enable_tls=$(grep "^http_enable_tls" "$graylog_config" | awk -F '=' '{print $2}' | awk '{$1=$1};1')
 
 	# FIX https://github.com/Graylog2/graylog-docker/issues/102
 	# This will remove the protocol from the URI if set via


### PR DESCRIPTION
We previously installed the configuration files into the GRAYLOG_HOME/data/config directory. We also documented that users should mount a volume to GRAYLOG_HOME/data to persist data.

When using a volume mount, Docker will copy existing files in GRAYLOG_HOME/data to the new volume. When using a bind mount (e.g., local directory), the directory doesn't include existing files, and the server refuses to start because it can't find the config files.

With the config files outside the data directory, this will no longer happen.

The entrypoint script will use existing config files in data/config to ensure existing setups with modified config files continue to work when updating to the new image.

See https://github.com/Graylog2/docker-compose/issues/99 for details.

Also, adjust the list of directories that get created in GRAYLOG_HOME/data. We don't need the log and plugin directories.
