### PR TITLE
Add conditional root check to datanode entrypoint

### DIFF
--- a/docker/datanode/entrypoint.sh
+++ b/docker/datanode/entrypoint.sh
@@ -45,6 +45,12 @@ check_env "GDN_GROUP"
 check_env "GRAYLOG_DATANODE_PASSWORD_SECRET"
 check_env "GRAYLOG_DATANODE_MONGODB_URI"
 
+# If not running as root, GDN_RUN_AS_NONROOT must be explicitly set to 'true'
+if [ "$(id -u)" != "0" ] && [ "$GDN_RUN_AS_NONROOT" != "true" ]; then
+	echo >&2 "ERROR: Container is not running as root but GDN_RUN_AS_NONROOT is not set to 'true'"
+	exit 1
+fi
+
 # Default Graylog settings
 export GRAYLOG_DATANODE_BIN_DIR="${GDN_APP_ROOT}/bin"
 export GRAYLOG_DATANODE_DATA_DIR="${GRAYLOG_DATANODE_DATA_DIR:-$GDN_DATA_ROOT}"
@@ -72,18 +78,37 @@ export DATANODE_JVM_OPTIONS_FILE="${DATANODE_JVM_OPTIONS_FILE:-"$GDN_JVM_OPTIONS
 export DATANODE_LOG4J_CONFIG_FILE="${DATANODE_LOG4J_CONFIG_FILE:-"$GDN_LOG4J_CONFIG_FILE"}"
 export JAVA_OPTS="$JAVA_OPTS"
 
-# Create required OpenSearch directories
-install -d -o "$GDN_USER" -g "$GDN_GROUP" -m 0700 \
-	"$GRAYLOG_DATANODE_OPENSEARCH_CONFIG_LOCATION" \
-	"$GRAYLOG_DATANODE_OPENSEARCH_DATA_LOCATION" \
-	"$GRAYLOG_DATANODE_OPENSEARCH_LOGS_LOCATION"
+# Only perform privilege operations if running as root
+if [ "$(id -u)" = "0" ]; then
+	# Create required OpenSearch directories with root privileges
+	install -d -o "$GDN_USER" -g "$GDN_GROUP" -m 0700 \
+		"$GRAYLOG_DATANODE_OPENSEARCH_CONFIG_LOCATION" \
+		"$GRAYLOG_DATANODE_OPENSEARCH_DATA_LOCATION" \
+		"$GRAYLOG_DATANODE_OPENSEARCH_LOGS_LOCATION"
 
-# Make sure the data node can write to the data dir
-chown -R "$GDN_USER":"$GDN_GROUP" "$GRAYLOG_DATANODE_DATA_DIR"
+	# Make sure the data node can write to the data dir
+	chown -R "$GDN_USER":"$GDN_GROUP" "$GRAYLOG_DATANODE_DATA_DIR"
 
-# Starting the data node with dropped privileges
-exec setpriv --reuid="$GDN_USER" --regid="$GDN_GROUP" --init-groups \
-	"${GRAYLOG_DATANODE_BIN_DIR}/graylog-datanode" \
-	datanode \
-	-f "$GDN_CONFIG_FILE" \
-	-ff "$GDN_FEATURE_FLAG_FILE"
+	# Starting the data node with dropped privileges
+	exec setpriv --reuid="$GDN_USER" --regid="$GDN_GROUP" --init-groups \
+		"${GRAYLOG_DATANODE_BIN_DIR}/graylog-datanode" \
+		datanode \
+		-f "$GDN_CONFIG_FILE" \
+		-ff "$GDN_FEATURE_FLAG_FILE"
+else
+	# Non-root execution: create directories and set permissions
+	# (user can chmod directories it owns)
+	mkdir -p "$GRAYLOG_DATANODE_OPENSEARCH_CONFIG_LOCATION" \
+		"$GRAYLOG_DATANODE_OPENSEARCH_DATA_LOCATION" \
+		"$GRAYLOG_DATANODE_OPENSEARCH_LOGS_LOCATION"
+
+	chmod 0700 "$GRAYLOG_DATANODE_OPENSEARCH_CONFIG_LOCATION" \
+		"$GRAYLOG_DATANODE_OPENSEARCH_DATA_LOCATION" \
+		"$GRAYLOG_DATANODE_OPENSEARCH_LOGS_LOCATION"
+
+	# If not running as root, execute the datanode directly
+	exec "${GRAYLOG_DATANODE_BIN_DIR}/graylog-datanode" \
+		datanode \
+		-f "$GDN_CONFIG_FILE" \
+		-ff "$GDN_FEATURE_FLAG_FILE"
+fi


### PR DESCRIPTION
## Summary
Add support for running the datanode container as non-root while maintaining backward compatibility with root execution.

This change allows the datanode to work in restricted environments that don't allow root containers, e.g. security-hardened Kubernetes clusters (Pod Security Standards, policies, OpenShift, etc.)

## Changes
Add branching based on the user running the entrypoint:
- When running as root: Uses `install -d` with proper ownership, performs `chown`, and drops privileges via `setpriv` (traditional behavior)
- When running as non-root: Creates directories with `mkdir`, sets `chmod 0700` (user can chmod its own directories), and executes datanode directly

## Why is this necessary?

In order to make the official Graylog Helm chart ready for security-hardened production environments, DataNode must be able to run as non root. This is possible in Kubernetes as setting up the right `securityContext` makes the `chown` and `setpriv` operations here unnecessary. A flag must be passed explicitly when running in this mode (as an env var: `GDN_RUN_AS_NONROOT=true`), so it doesn't occur by accident.

## Impact
- Enables deployment in restricted environments without requiring a root init container
- Maintains same security posture (0700 permissions) in both paths
- Works seamlessly with Kubernetes `fsGroup` for volume ownership
- Complements graylog-helm security hardening efforts

## Related

https://github.com/Graylog2/graylog-helm/pull/100

## Testing
- [x] Tested with root execution (7.1 branch)
- [x] Tested with non-root execution (uid 1100)
- [x] Verified directory permissions are correct (0700)
- [x] Verified datanode starts successfully in both modes


## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

