### PR TITLE
Fix OpenSearch directory resolution

### DIFF
--- a/docker/datanode/entrypoint.sh
+++ b/docker/datanode/entrypoint.sh
@@ -56,16 +56,7 @@ export GRAYLOG_DATANODE_OPENSEARCH_LOGS_LOCATION="${GRAYLOG_DATANODE_OPENSEARCH_
 export GRAYLOG_DATANODE_OPENSEARCH_HTTP_PORT="${GRAYLOG_DATANODE_OPENSEARCH_HTTP_PORT:-9200}"
 export GRAYLOG_DATANODE_OPENSEARCH_TRANSPORT_PORT="${GRAYLOG_DATANODE_OPENSEARCH_TRANSPORT_PORT:-9300}"
 export GRAYLOG_DATANODE_NODE_NAME="${GRAYLOG_DATANODE_NODE_NAME:-"$HOSTNAME"}"
-
-# TODO: Bundle the OpenSearch version property in the tarball so we can read it
-opensearch_dist="$(find "$GDN_APP_ROOT/dist" -maxdepth 1 -name 'opensearch-*-linux-*' -type d | sort -V | tail -1)"
-
-if [ -z "$opensearch_dist" ]; then
-	echo "ERROR: No OpenSearch distribution found in $GDN_APP_ROOT/dist"
-	exit 1
-fi
-
-export GRAYLOG_DATANODE_OPENSEARCH_LOCATION="$opensearch_dist"
+export GRAYLOG_DATANODE_OPENSEARCH_LOCATION="$GDN_APP_ROOT/dist"
 
 # Settings for the graylog-datanode script
 export DATANODE_JVM_OPTIONS_FILE="${DATANODE_JVM_OPTIONS_FILE:-"$GDN_JVM_OPTIONS_FILE"}"


### PR DESCRIPTION
Data node now ships with two Opensearch versions and resolves the correct dir to use itself.

This PR changes the Opensearch location to point to the `dist` directory, not the version specific Opensearch directory below, which data node 7.2 uses for resolution of the correct version.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

